### PR TITLE
Improve EOF handling

### DIFF
--- a/car/main.go
+++ b/car/main.go
@@ -26,7 +26,7 @@ var headerCmd = cli.Command{
 		}
 		defer fi.Close()
 
-		ch, err := car.ReadHeader(bufio.NewReader(fi))
+		ch, _, err := car.ReadHeader(bufio.NewReader(fi))
 		if err != nil {
 			return err
 		}

--- a/util/util.go
+++ b/util/util.go
@@ -100,8 +100,15 @@ func LdSize(d ...[]byte) uint64 {
 }
 
 func LdRead(r *bufio.Reader) ([]byte, error) {
+	if _, err := r.Peek(1); err != nil { // no more blocks, likely clean io.EOF
+		return nil, err
+	}
+
 	l, err := binary.ReadUvarint(r)
 	if err != nil {
+		if err == io.EOF {
+			return nil, io.ErrUnexpectedEOF // don't silently pretend this is a clean EOF
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
This came up from go-ipfs folks trying to import a CAR file that was truncated but they had no indication that it was. The final block had an `0xa0` after it, which is an improper varint, so `ReadUvarint()` was returning an `io.EOF` which also happens if there's _no_ next block at all and is therefore the proper-EOF signal. This change lifts the proper-EOF case out into a `Peek(1)` so every other EOF from there on can be assumed to be unexpected.