### PR TITLE
chore: remove LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,0 @@
-This project is dual-licensed under Apache 2.0 and MIT terms.
-
-MIT: https://www.opensource.org/licenses/mit
-Apache-2.0: https://www.apache.org/licenses/license-2.0


### PR DESCRIPTION
It looks like this may be confusing pkg.go.dev's license detection.