### PR TITLE
Header error tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+car/car
+main
+coverage.txt

--- a/car.go
+++ b/car.go
@@ -77,7 +77,7 @@ func ReadHeader(br *bufio.Reader) (*CarHeader, error) {
 
 	var ch CarHeader
 	if err := cbor.DecodeInto(hb, &ch); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("invalid header: %v", err)
 	}
 
 	return &ch, nil
@@ -130,12 +130,12 @@ func NewCarReader(r io.Reader) (*CarReader, error) {
 		return nil, err
 	}
 
-	if len(ch.Roots) == 0 {
-		return nil, fmt.Errorf("empty car")
-	}
-
 	if ch.Version != 1 {
 		return nil, fmt.Errorf("invalid car version: %d", ch.Version)
+	}
+
+	if len(ch.Roots) == 0 {
+		return nil, fmt.Errorf("empty car, no roots")
 	}
 
 	return &CarReader{

--- a/car_test.go
+++ b/car_test.go
@@ -237,6 +237,58 @@ func TestEOFHandling(t *testing.T) {
 }
 
 func TestBadHeaders(t *testing.T) {
+	testCases := []struct {
+		name   string
+		hex    string
+		errStr string // either the whole error string
+		errPfx string // or just the prefix
+	}{
+		{
+			"{version:2}",
+			"0aa16776657273696f6e02",
+			"invalid car version: 2",
+			"",
+		},
+		{
+			// an unfortunate error because we don't use a pointer
+			"{roots:[baeaaaa3bmjrq]}",
+			"13a165726f6f747381d82a480001000003616263",
+			"invalid car version: 0",
+			"",
+		}, {
+			"{version:\"1\",roots:[baeaaaa3bmjrq]}",
+			"1da265726f6f747381d82a4800010000036162636776657273696f6e6131",
+			"", "invalid header: ",
+		}, {
+			"{version:1}",
+			"0aa16776657273696f6e01",
+			"empty car, no roots",
+			"",
+		}, {
+			"{version:1,roots:{cid:baeaaaa3bmjrq}}",
+			"20a265726f6f7473a163636964d82a4800010000036162636776657273696f6e01",
+			"",
+			"invalid header: ",
+		}, {
+			"{version:1,roots:[baeaaaa3bmjrq],blip:true}",
+			"22a364626c6970f565726f6f747381d82a4800010000036162636776657273696f6e01",
+			"",
+			"invalid header: ",
+		}, {
+			"[1,[]]",
+			"03820180",
+			"",
+			"invalid header: ",
+		}, {
+			// this is an unfortunate error, it'd be nice to catch it better but it's
+			// very unlikely we'd ever see this in practice
+			"null",
+			"01f6",
+			"",
+			"invalid car version: 0",
+		},
+	}
+
 	makeCar := func(t *testing.T, byts string) error {
 		fixture, err := hex.DecodeString(byts)
 		if err != nil {
@@ -253,62 +305,18 @@ func TestBadHeaders(t *testing.T) {
 		}
 	})
 
-	t.Run("{version:2}", func(t *testing.T) {
-		err := makeCar(t, "0aa16776657273696f6e02")
-		if err.Error() != "invalid car version: 2" {
-			t.Fatalf("bad error: %v", err)
-		}
-	})
-
-	// an unfortunate error because we don't use a pointer
-	t.Run("{roots:[baeaaaa3bmjrq]}", func(t *testing.T) {
-		err := makeCar(t, "13a165726f6f747381d82a480001000003616263")
-		if err.Error() != "invalid car version: 0" {
-			t.Fatalf("bad error: %v", err)
-		}
-	})
-
-	t.Run("{version:\"1\",roots:[baeaaaa3bmjrq]}", func(t *testing.T) {
-		err := makeCar(t, "1da265726f6f747381d82a4800010000036162636776657273696f6e6131")
-		if !strings.HasPrefix(err.Error(), "invalid header: ") {
-			t.Fatalf("bad error: %v", err)
-		}
-	})
-
-	t.Run("{version:1}", func(t *testing.T) {
-		err := makeCar(t, "0aa16776657273696f6e01")
-		if err.Error() != "empty car, no roots" {
-			t.Fatalf("bad error: %v", err)
-		}
-	})
-
-	t.Run("{version:1,roots:{cid:baeaaaa3bmjrq}}", func(t *testing.T) {
-		err := makeCar(t, "20a265726f6f7473a163636964d82a4800010000036162636776657273696f6e01")
-		if !strings.HasPrefix(err.Error(), "invalid header: ") {
-			t.Fatalf("bad error: %v", err)
-		}
-	})
-
-	t.Run("{version:1,roots:[baeaaaa3bmjrq],blip:true}", func(t *testing.T) {
-		err := makeCar(t, "22a364626c6970f565726f6f747381d82a4800010000036162636776657273696f6e01")
-		if !strings.HasPrefix(err.Error(), "invalid header: ") {
-			t.Fatalf("bad error: %v", err)
-		}
-	})
-
-	t.Run("[1,[]]", func(t *testing.T) {
-		err := makeCar(t, "03820180")
-		if !strings.HasPrefix(err.Error(), "invalid header: ") {
-			t.Fatalf("bad error: %v", err)
-		}
-	})
-
-	// this is an unfortunate error, it'd be nice to catch it better but it's
-	// very unlikely we'd ever see this in practice
-	t.Run("null", func(t *testing.T) {
-		err := makeCar(t, "01f6")
-		if !strings.HasPrefix(err.Error(), "invalid car version: 0") {
-			t.Fatalf("bad error: %v", err)
-		}
-	})
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := makeCar(t, tc.hex)
+			if tc.errStr != "" {
+				if err.Error() != tc.errStr {
+					t.Fatalf("bad error: %v", err)
+				}
+			} else {
+				if !strings.HasPrefix(err.Error(), tc.errPfx) {
+					t.Fatalf("bad error: %v", err)
+				}
+			}
+		})
+	}
 }

--- a/car_test.go
+++ b/car_test.go
@@ -308,6 +308,9 @@ func TestBadHeaders(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			err := makeCar(t, tc.hex)
+			if err == nil {
+				t.Fatal("expected error from bad header, didn't get one")
+			}
 			if tc.errStr != "" {
 				if err.Error() != tc.errStr {
 					t.Fatalf("bad error: %v", err)


### PR DESCRIPTION
Also pulls in #74 and #75

Ref: ipld/js-car#28

> Also included in this is an explicit check for `0aa16776657273696f6e02` (`<length>{version:2}`) as per https://github.com/ipld/specs/pull/248#issuecomment-833141588 so it can be used as a CARv2 escape - if we end up using this string as a modifier for CARv2 we can at least get proper errors out of this if it encounters a newer format.

the primary difference with js-car is that go-car requires a non-empty roots array whereas js-car is fine with empty roots array, hence the test fixture differences
