### PR TITLE
Remove redundant .gx folder in light of `go.mod`

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,0 @@
-1.1.11: QmUGpiTCKct5s1F7jaAnY9KJmoo7Qm1R2uhSjq5iHDSUMn


### PR DESCRIPTION
The `.gx` dependency management mechanism seems to date back before go
mod. The folder is untouched for the last 2 years and the repo is using
go mod already.

Removing it now that it is made redundant.
