### PR TITLE
Define CAR v2 as a separate go module

### DIFF
--- a/v2/doc.go
+++ b/v2/doc.go
@@ -1,0 +1,3 @@
+// Package car represents the CAR v2 implementation.
+// TODO add CAR v2 byte structure here.
+package car

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -1,0 +1,3 @@
+module github.com/ipld/go-car/v2
+
+go 1.15


### PR DESCRIPTION
Note, the entire approach to CAR v2 implementation and package structure is work in progress, hence this PR is against `wip/v2`. For context see https://github.com/ipld/go-car/pull/78#discussion_r648314538

Since we are releasing a new major version, define a new go module for
the CAR v2 implementation, following the recommendations here:
- https://blog.golang.org/v2-go-modules

The module is versioned as go 1.15 to maintain compatibility as pointed
out by comment here:
- https://github.com/ipld/go-car/pull/75#discussion_r644634850