### PR TITLE
Run `gofumpt -l -w .`

### DIFF
--- a/v2/blockstore/readonly_test.go
+++ b/v2/blockstore/readonly_test.go
@@ -1,9 +1,10 @@
 package blockstore
 
 import (
-	"github.com/ipld/go-car/v2/internal/index"
 	"os"
 	"testing"
+
+	"github.com/ipld/go-car/v2/internal/index"
 )
 
 /*

--- a/v2/car.go
+++ b/v2/car.go
@@ -14,16 +14,14 @@ const (
 	CharacteristicsSize = 16
 )
 
-var (
-	// The fixed prefix of a CAR v2, signalling the version number to previous versions for graceful fail over.
-	PrefixBytes = []byte{
-		0x0a,                                     // unit(10)
-		0xa1,                                     // map(1)
-		0x67,                                     // string(7)
-		0x76, 0x65, 0x72, 0x73, 0x69, 0x6f, 0x6e, // "version"
-		0x02, // uint(2)
-	}
-)
+// The fixed prefix of a CAR v2, signalling the version number to previous versions for graceful fail over.
+var PrefixBytes = []byte{
+	0x0a,                                     // unit(10)
+	0xa1,                                     // map(1)
+	0x67,                                     // string(7)
+	0x76, 0x65, 0x72, 0x73, 0x69, 0x6f, 0x6e, // "version"
+	0x02, // uint(2)
+}
 
 type (
 	// Header represents the CAR v2 header/pragma.

--- a/v2/car_test.go
+++ b/v2/car_test.go
@@ -3,10 +3,11 @@ package car_test
 import (
 	"bufio"
 	"bytes"
+	"testing"
+
 	carv1 "github.com/ipld/go-car"
 	carv2 "github.com/ipld/go-car/v2"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestCarV2PrefixLength(t *testing.T) {
@@ -99,6 +100,7 @@ func TestHeader_WriteTo(t *testing.T) {
 		})
 	}
 }
+
 func TestHeader_ReadFrom(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/v2/internal/carbon/carbon.go
+++ b/v2/internal/carbon/carbon.go
@@ -3,9 +3,10 @@ package carbon
 import (
 	"errors"
 	"fmt"
+	"os"
+
 	carblockstore "github.com/ipld/go-car/v2/blockstore"
 	"github.com/ipld/go-car/v2/internal/index"
-	"os"
 
 	"github.com/ipfs/go-cid"
 	blockstore "github.com/ipfs/go-ipfs-blockstore"
@@ -29,11 +30,11 @@ func New(path string) (Carbon, error) {
 
 // NewWithRoots creates a new Carbon blockstore with a provided set of root cids as the car roots
 func NewWithRoots(path string, roots []cid.Cid) (Carbon, error) {
-	wfd, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0666)
+	wfd, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o666)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't create backing car: %w", err)
 	}
-	rfd, err := os.OpenFile(path, os.O_RDONLY, 0666)
+	rfd, err := os.OpenFile(path, os.O_RDONLY, 0o666)
 	if err != nil {
 		return nil, fmt.Errorf("could not re-open read handle: %w", err)
 	}

--- a/v2/internal/carbon/carbon_fds.go
+++ b/v2/internal/carbon/carbon_fds.go
@@ -1,9 +1,10 @@
 package carbon
 
 import (
+	"os"
+
 	"github.com/ipld/go-car/v2/blockstore"
 	"github.com/ipld/go-car/v2/internal/index"
-	"os"
 
 	blocks "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-cid"

--- a/v2/internal/carbon/carbon_test.go
+++ b/v2/internal/carbon/carbon_test.go
@@ -1,12 +1,13 @@
 package carbon_test
 
 import (
-	"github.com/ipld/go-car/v2/blockstore"
-	"github.com/ipld/go-car/v2/internal/carbon"
 	"io"
 	"math/rand"
 	"os"
 	"testing"
+
+	"github.com/ipld/go-car/v2/blockstore"
+	"github.com/ipld/go-car/v2/internal/carbon"
 
 	"github.com/ipfs/go-cid"
 	"github.com/ipld/go-car"

--- a/v2/internal/carbs/util/hydrate.go
+++ b/v2/internal/carbs/util/hydrate.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/ipld/go-car/v2/internal/index"
 	"golang.org/x/exp/mmap"
-	"os"
 )
 
 func main() {

--- a/v2/internal/index/generator.go
+++ b/v2/internal/index/generator.go
@@ -4,11 +4,12 @@ import (
 	"bufio"
 	"encoding/binary"
 	"fmt"
+	"io"
+
 	"github.com/cheggaaa/pb/v3"
 	carv1 "github.com/ipld/go-car"
 	internalio "github.com/ipld/go-car/v2/internal/io"
 	"golang.org/x/exp/mmap"
-	"io"
 )
 
 // GenerateIndex provides a low-level interface to create an index over a

--- a/v2/internal/index/index.go
+++ b/v2/internal/index/index.go
@@ -3,11 +3,12 @@ package index
 import (
 	"encoding/binary"
 	"fmt"
+	"io"
+	"os"
+
 	"github.com/ipfs/go-cid"
 	internalio "github.com/ipld/go-car/v2/internal/io"
 	"golang.org/x/exp/mmap"
-	"io"
-	"os"
 )
 
 // Codec table is a first var-int in carbs indexes
@@ -53,7 +54,7 @@ var IndexAtlas = map[Codec]IndexCls{
 
 // Save writes a generated index for a car at `path`
 func Save(i Index, path string) error {
-	stream, err := os.OpenFile(path+".idx", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0640)
+	stream, err := os.OpenFile(path+".idx", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o640)
 	if err != nil {
 		return err
 	}

--- a/v2/internal/io/cid.go
+++ b/v2/internal/io/cid.go
@@ -4,9 +4,10 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+	"io"
+
 	"github.com/ipfs/go-cid"
 	"github.com/multiformats/go-multihash"
-	"io"
 )
 
 var cidv0Pref = []byte{0x12, 0x20}

--- a/v2/reader.go
+++ b/v2/reader.go
@@ -3,8 +3,9 @@ package car
 import (
 	"bufio"
 	"fmt"
-	internalio "github.com/ipld/go-car/v2/internal/io"
 	"io"
+
+	internalio "github.com/ipld/go-car/v2/internal/io"
 
 	carv1 "github.com/ipld/go-car"
 )

--- a/v2/writer_test.go
+++ b/v2/writer_test.go
@@ -3,13 +3,14 @@ package car
 import (
 	"bytes"
 	"context"
+	"testing"
+
 	"github.com/ipfs/go-cid"
 	format "github.com/ipfs/go-ipld-format"
 	dag "github.com/ipfs/go-merkledag"
 	dstest "github.com/ipfs/go-merkledag/test"
 	"github.com/ipld/go-car/v2/internal/index"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestPadding_WriteTo(t *testing.T) {


### PR DESCRIPTION
Format code in v2 consistently using `gofumpt -l -w .`