### PR TITLE
Rename Prefix to Pragma for consistency

### DIFF
--- a/v2/car.go
+++ b/v2/car.go
@@ -6,16 +6,17 @@ import (
 )
 
 const (
-	// PrefixSize is the size of the CAR v2 prefix in 11 bytes, (i.e. 11).
-	PrefixSize = 11
+	// PragmaSize is the size of the CAR v2 pragma in bytes.
+	PragmaSize = 11
 	// HeaderSize is the fixed size of CAR v2 header in number of bytes.
 	HeaderSize = 40
 	// CharacteristicsSize is the fixed size of Characteristics bitfield within CAR v2 header in number of bytes.
 	CharacteristicsSize = 16
 )
 
-// The fixed prefix of a CAR v2, signalling the version number to previous versions for graceful fail over.
-var PrefixBytes = []byte{
+// The pragma of a CAR v2, containing the version number..
+// This is a valid CAR v1 header, with version number set to 2.
+var Pragma = []byte{
 	0x0a,                                     // unit(10)
 	0xa1,                                     // map(1)
 	0x67,                                     // string(7)
@@ -68,15 +69,15 @@ func NewHeader(carV1Size uint64) Header {
 	header := Header{
 		CarV1Size: carV1Size,
 	}
-	header.CarV1Offset = PrefixSize + HeaderSize
+	header.CarV1Offset = PragmaSize + HeaderSize
 	header.IndexOffset = header.CarV1Offset + carV1Size
 	return header
 }
 
 // WithIndexPadding sets the index offset from the beginning of the file for this header and returns the
 // header for convenient chained calls.
-// The index offset is calculated as the sum of PrefixBytesLen, HeaderBytesLen,
-// Header.CarV1Len, and the given padding.
+// The index offset is calculated as the sum of PragmaSize, HeaderSize,
+// Header.CarV1Size, and the given padding.
 func (h Header) WithIndexPadding(padding uint64) Header {
 	h.IndexOffset = h.IndexOffset + padding
 	return h
@@ -84,7 +85,7 @@ func (h Header) WithIndexPadding(padding uint64) Header {
 
 // WithCarV1Padding sets the CAR v1 dump offset from the beginning of the file for this header and returns the
 // header for convenient chained calls.
-// The CAR v1 offset is calculated as the sum of PrefixBytesLen, HeaderBytesLen and the given padding.
+// The CAR v1 offset is calculated as the sum of PragmaSize, HeaderSize and the given padding.
 // The call to this function also shifts the Header.IndexOffset forward by the given padding.
 func (h Header) WithCarV1Padding(padding uint64) Header {
 	h.CarV1Offset = h.CarV1Offset + padding

--- a/v2/car_test.go
+++ b/v2/car_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCarV2PrefixLength(t *testing.T) {
+func TestCarV2PragmaLength(t *testing.T) {
 	tests := []struct {
 		name string
 		want interface{}
@@ -19,29 +19,29 @@ func TestCarV2PrefixLength(t *testing.T) {
 		{
 			"ActualSizeShouldBe11",
 			11,
-			len(carv2.PrefixBytes),
+			len(carv2.Pragma),
 		},
 		{
 			"ShouldStartWithVarint(10)",
-			carv2.PrefixBytes[0],
+			carv2.Pragma[0],
 			10,
 		},
 	}
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			assert.EqualValues(t, tt.want, tt.got, "CarV2Prefix got = %v, want %v", tt.got, tt.want)
+			assert.EqualValues(t, tt.want, tt.got, "CarV2Pragma got = %v, want %v", tt.got, tt.want)
 		})
 	}
 }
 
-func TestCarV2PrefixIsValidCarV1Header(t *testing.T) {
-	v1h, err := carv1.ReadHeader(bufio.NewReader(bytes.NewReader(carv2.PrefixBytes)))
-	assert.NoError(t, err, "cannot decode prefix as CBOR with CAR v1 header structure")
+func TestCarV2PragmaIsValidCarV1Header(t *testing.T) {
+	v1h, err := carv1.ReadHeader(bufio.NewReader(bytes.NewReader(carv2.Pragma)))
+	assert.NoError(t, err, "cannot decode pragma as CBOR with CAR v1 header structure")
 	assert.Equal(t, &carv1.CarHeader{
 		Roots:   nil,
 		Version: 2,
-	}, v1h, "CAR v2 prefix must be a valid CAR v1 header")
+	}, v1h, "CAR v2 pragma must be a valid CAR v1 header")
 }
 
 func TestHeader_WriteTo(t *testing.T) {
@@ -164,20 +164,20 @@ func TestHeader_WithPadding(t *testing.T) {
 		{
 			"WhenNoPaddingOffsetsAreSumOfSizes",
 			carv2.NewHeader(123),
-			carv2.PrefixSize + carv2.HeaderSize,
-			carv2.PrefixSize + carv2.HeaderSize + 123,
+			carv2.PragmaSize + carv2.HeaderSize,
+			carv2.PragmaSize + carv2.HeaderSize + 123,
 		},
 		{
 			"WhenOnlyPaddingCarV1BothOffsetsShift",
 			carv2.NewHeader(123).WithCarV1Padding(3),
-			carv2.PrefixSize + carv2.HeaderSize + 3,
-			carv2.PrefixSize + carv2.HeaderSize + 3 + 123,
+			carv2.PragmaSize + carv2.HeaderSize + 3,
+			carv2.PragmaSize + carv2.HeaderSize + 3 + 123,
 		},
 		{
 			"WhenPaddingBothCarV1AndIndexBothOffsetsShiftWithAdditionalIndexShift",
 			carv2.NewHeader(123).WithCarV1Padding(3).WithIndexPadding(7),
-			carv2.PrefixSize + carv2.HeaderSize + 3,
-			carv2.PrefixSize + carv2.HeaderSize + 3 + 123 + 7,
+			carv2.PragmaSize + carv2.HeaderSize + 3,
+			carv2.PragmaSize + carv2.HeaderSize + 3 + 123 + 7,
 		},
 	}
 
@@ -193,9 +193,9 @@ func TestNewHeaderHasExpectedValues(t *testing.T) {
 	wantCarV1Len := uint64(1413)
 	want := carv2.Header{
 		Characteristics: carv2.Characteristics{},
-		CarV1Offset:     carv2.PrefixSize + carv2.HeaderSize,
+		CarV1Offset:     carv2.PragmaSize + carv2.HeaderSize,
 		CarV1Size:       wantCarV1Len,
-		IndexOffset:     carv2.PrefixSize + carv2.HeaderSize + wantCarV1Len,
+		IndexOffset:     carv2.PragmaSize + carv2.HeaderSize + wantCarV1Len,
 	}
 	got := carv2.NewHeader(wantCarV1Len)
 	assert.Equal(t, want, got, "NewHeader got = %v, want = %v", got, want)

--- a/v2/reader.go
+++ b/v2/reader.go
@@ -25,7 +25,7 @@ func NewReader(r io.ReaderAt) (*Reader, error) {
 	cr := &Reader{
 		r: r,
 	}
-	if err := cr.readPrefix(); err != nil {
+	if err := cr.readPragma(); err != nil {
 		return nil, err
 	}
 	if err := cr.readHeader(); err != nil {
@@ -34,8 +34,8 @@ func NewReader(r io.ReaderAt) (*Reader, error) {
 	return cr, nil
 }
 
-func (r *Reader) readPrefix() (err error) {
-	pr := io.NewSectionReader(r.r, 0, PrefixSize)
+func (r *Reader) readPragma() (err error) {
+	pr := io.NewSectionReader(r.r, 0, PragmaSize)
 	header, err := carv1.ReadHeader(bufio.NewReader(pr))
 	if err != nil {
 		return
@@ -47,7 +47,7 @@ func (r *Reader) readPrefix() (err error) {
 }
 
 func (r *Reader) readHeader() (err error) {
-	headerSection := io.NewSectionReader(r.r, PrefixSize, HeaderSize)
+	headerSection := io.NewSectionReader(r.r, PragmaSize, HeaderSize)
 	_, err = r.Header.ReadFrom(headerSection)
 	return
 }

--- a/v2/writer.go
+++ b/v2/writer.go
@@ -72,11 +72,11 @@ func NewWriter(ctx context.Context, ng format.NodeGetter, roots []cid.Cid) *Writ
 // WriteTo writes the given root CIDs according to CAR v2 specification, traversing the DAG using the
 // Writer.Walk function.
 func (w *Writer) WriteTo(writer io.Writer) (n int64, err error) {
-	_, err = writer.Write(PrefixBytes)
+	_, err = writer.Write(Pragma)
 	if err != nil {
 		return
 	}
-	n += int64(PrefixSize)
+	n += int64(PragmaSize)
 	// We read the entire car into memory because carbs.GenerateIndex takes a reader.
 	// Future PRs will make this more efficient by exposing necessary interfaces in carbs so that
 	// this can be done in an streaming manner.


### PR DESCRIPTION
Pragma seems like a better name for the prefix bytes of a car v2. Rename
it along with references to it in tests etc.

It also helps keep the terminology consistent with the [finalising specification](https://github.com/ipld/ipld/pull/107)