### PR TITLE
Remove dependency to CAR v1 go module

### DIFF
--- a/v2/blockstore/readonly.go
+++ b/v2/blockstore/readonly.go
@@ -11,10 +11,10 @@ import (
 	blocks "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-cid"
 	blockstore "github.com/ipfs/go-ipfs-blockstore"
-	carv1 "github.com/ipld/go-car"
-	"github.com/ipld/go-car/util"
 	carv2 "github.com/ipld/go-car/v2"
 	"github.com/ipld/go-car/v2/index"
+	"github.com/ipld/go-car/v2/internal/carv1"
+	"github.com/ipld/go-car/v2/internal/carv1/util"
 	internalio "github.com/ipld/go-car/v2/internal/io"
 	"golang.org/x/exp/mmap"
 )

--- a/v2/blockstore/readwrite.go
+++ b/v2/blockstore/readwrite.go
@@ -7,15 +7,15 @@ import (
 	"os"
 
 	blockstore "github.com/ipfs/go-ipfs-blockstore"
-	carv1 "github.com/ipld/go-car"
 	carv2 "github.com/ipld/go-car/v2"
+	"github.com/ipld/go-car/v2/internal/carv1"
 	internalio "github.com/ipld/go-car/v2/internal/io"
 
 	"github.com/ipld/go-car/v2/index"
 
 	blocks "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-cid"
-	"github.com/ipld/go-car/util"
+	"github.com/ipld/go-car/v2/internal/carv1/util"
 )
 
 var (

--- a/v2/blockstore/readwrite_test.go
+++ b/v2/blockstore/readwrite_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/ipld/go-car/v2/blockstore"
 
 	"github.com/ipfs/go-cid"
-	carv1 "github.com/ipld/go-car"
+	"github.com/ipld/go-car/v2/internal/carv1"
 )
 
 func TestBlockstore(t *testing.T) {

--- a/v2/car_test.go
+++ b/v2/car_test.go
@@ -5,8 +5,8 @@ import (
 	"bytes"
 	"testing"
 
-	carv1 "github.com/ipld/go-car"
 	carv2 "github.com/ipld/go-car/v2"
+	"github.com/ipld/go-car/v2/internal/carv1"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -6,9 +6,9 @@ require (
 	github.com/ipfs/go-block-format v0.0.3
 	github.com/ipfs/go-cid v0.0.7
 	github.com/ipfs/go-ipfs-blockstore v1.0.3
+	github.com/ipfs/go-ipld-cbor v0.0.5
 	github.com/ipfs/go-ipld-format v0.2.0
 	github.com/ipfs/go-merkledag v0.3.2
-	github.com/ipld/go-car v0.3.1
 	github.com/mattn/go-colorable v0.1.8 // indirect
 	github.com/multiformats/go-multihash v0.0.15
 	github.com/petar/GoLLRB v0.0.0-20210522233825-ae3b015fd3e9
@@ -17,5 +17,3 @@ require (
 	golang.org/x/exp v0.0.0-20210615023648-acb5c1269671
 	golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57 // indirect
 )
-
-replace github.com/ipld/go-car => ../

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -76,8 +76,6 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db/go.mod h1:7dvUGVsVBjqR7JHJk0brhHOZYGmfBYOrK0ZhYMEtBr4=
 github.com/franela/goreq v0.0.0-20171204163338-bcd34c9993f8/go.mod h1:ZhphrRTfi2rbfLwlschooIH4+wKKDR4Pdxhh+TRoA20=
-github.com/frankban/quicktest v1.11.3 h1:8sXhOn0uLys67V8EsXLc6eszDs8VXWxL3iRvebPhedY=
-github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM0I9ntUbOk+k=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -114,8 +112,6 @@ github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5a
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
@@ -178,7 +174,6 @@ github.com/ipfs/go-blockservice v0.1.0/go.mod h1:hzmMScl1kXHg3M2BjTymbVPjv627N7s
 github.com/ipfs/go-cid v0.0.1/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-cid v0.0.2/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-cid v0.0.3/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
-github.com/ipfs/go-cid v0.0.4/go.mod h1:4LLaPOQwmk5z9LBgQnpkivrx8BJjUyGwTXCd5Xfj6+M=
 github.com/ipfs/go-cid v0.0.5/go.mod h1:plgt+Y5MnOey4vO4UlUazGqdbEXuFYitED67FexhXog=
 github.com/ipfs/go-cid v0.0.7 h1:ysQJVJA3fNDF1qigJbsSQOdjhVLsOEoPdh0+R97k3jY=
 github.com/ipfs/go-cid v0.0.7/go.mod h1:6Ux9z5e+HpkQdckYoX1PG/6xqKspzlEIR5SDmgqgC/I=
@@ -233,10 +228,6 @@ github.com/ipfs/go-peertaskqueue v0.1.0 h1:bpRbgv76eT4avutNPDFZuCPOQus6qTgurEYxf
 github.com/ipfs/go-peertaskqueue v0.1.0/go.mod h1:Jmk3IyCcfl1W3jTW3YpghSwSEC6IJ3Vzz/jUmWw8Z0U=
 github.com/ipfs/go-verifcid v0.0.1 h1:m2HI7zIuR5TFyQ1b79Da5N9dnnCP1vcu2QqawmWlK2E=
 github.com/ipfs/go-verifcid v0.0.1/go.mod h1:5Hrva5KBeIog4A+UpqlaIU+DEstipcJYQQZc0g37pY0=
-github.com/ipld/go-codec-dagpb v1.2.0 h1:2umV7ud8HBMkRuJgd8gXw95cLhwmcYrihS3cQEy9zpI=
-github.com/ipld/go-codec-dagpb v1.2.0/go.mod h1:6nBN7X7h8EOsEejZGqC7tej5drsdBAXbMHyBT+Fne5s=
-github.com/ipld/go-ipld-prime v0.9.0 h1:N2OjJMb+fhyFPwPnVvJcWU/NsumP8etal+d2v3G4eww=
-github.com/ipld/go-ipld-prime v0.9.0/go.mod h1:KvBLMr4PX1gWptgkzRjVZCrLmSGcZCb/jioOQwCqZN8=
 github.com/jackpal/gateway v1.0.5 h1:qzXWUJfuMdlLMtt0a3Dgt+xkWQiA5itDEITVJtuSwMc=
 github.com/jackpal/gateway v1.0.5/go.mod h1:lTpwd4ACLXmpyiCTRtfiNyVnUmqT9RivzCDQetPfnjA=
 github.com/jackpal/go-nat-pmp v1.0.1 h1:i0LektDkO1QlrTm/cSuP+PyBCDnYvjPLGl4LdWEMiaA=
@@ -270,9 +261,8 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxv
 github.com/koron/go-ssdp v0.0.0-20180514024734-4a0ed625a78b h1:wxtKgYHEncAU00muMD06dzLiahtGM1eouRNOzVV7tdQ=
 github.com/koron/go-ssdp v0.0.0-20180514024734-4a0ed625a78b/go.mod h1:5Ky9EC2xfoUKUor0Hjgi2BJhCSXJfMOFlmyYrVKGQMk=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
-github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
-github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
@@ -462,10 +452,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/profile v1.2.1/go.mod h1:hJw3o1OdXxsrSjjVksARp5W95eeEaEfptyVZyv6JUPA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/polydawn/refmt v0.0.0-20190221155625-df39d6c2d992 h1:bzMe+2coZJYHnhGgVlcQKuRy4FSny4ds8dLQjw5P1XE=
 github.com/polydawn/refmt v0.0.0-20190221155625-df39d6c2d992/go.mod h1:uIp+gprXxxrWSjjklXD+mN4wed/tMfjMMmN/9+JsA9o=
-github.com/polydawn/refmt v0.0.0-20190807091052-3d65705ee9f1/go.mod h1:uIp+gprXxxrWSjjklXD+mN4wed/tMfjMMmN/9+JsA9o=
-github.com/polydawn/refmt v0.0.0-20201211092308-30ac6d18308e h1:ZOcivgkkFRnjfoTcGsDq3UQYiBmekwLA+qg0OjyB/ls=
-github.com/polydawn/refmt v0.0.0-20201211092308-30ac6d18308e/go.mod h1:uIp+gprXxxrWSjjklXD+mN4wed/tMfjMMmN/9+JsA9o=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829/go.mod h1:p2iRAGwDERtqlqzRXnrOVns+ignqQo//hLXqYxZYVNs=
@@ -524,9 +512,8 @@ github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpP
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
+github.com/warpfork/go-wish v0.0.0-20180510122957-5ad1f5abf436 h1:qOpVTI+BrstcjTZLm2Yz/3sOnqkzj3FQoh0g+E5s3Gc=
 github.com/warpfork/go-wish v0.0.0-20180510122957-5ad1f5abf436/go.mod h1:x6AKhvSSexNrVSrViXSHUEbICjmGXhtgABaHIySUSGw=
-github.com/warpfork/go-wish v0.0.0-20200122115046-b9ea61034e4a h1:G++j5e0OC488te356JvdhaM8YS6nMsjLAYF7JxCv07w=
-github.com/warpfork/go-wish v0.0.0-20200122115046-b9ea61034e4a/go.mod h1:x6AKhvSSexNrVSrViXSHUEbICjmGXhtgABaHIySUSGw=
 github.com/whyrusleeping/cbor v0.0.0-20171005072247-63513f603b11 h1:5HZfQkwe0mIfyDmc1Em5GqlNRzcdtlv4HTNmdpt7XH0=
 github.com/whyrusleeping/cbor v0.0.0-20171005072247-63513f603b11/go.mod h1:Wlo/SzPmxVp6vXpGt/zaXhHH0fn4IxgqZc82aKg6bpQ=
 github.com/whyrusleeping/cbor-gen v0.0.0-20200123233031-1cdf64d27158 h1:WXhVOwj2USAXB5oMDwRl3piOux2XMV9TANaYxXHdkoE=

--- a/v2/index/generator.go
+++ b/v2/index/generator.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"io"
 
-	carv1 "github.com/ipld/go-car"
+	"github.com/ipld/go-car/v2/internal/carv1"
 	internalio "github.com/ipld/go-car/v2/internal/io"
 	"golang.org/x/exp/mmap"
 )

--- a/v2/internal/carv1/car.go
+++ b/v2/internal/carv1/car.go
@@ -1,0 +1,222 @@
+package carv1
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/ipld/go-car/v2/internal/carv1/util"
+
+	blocks "github.com/ipfs/go-block-format"
+	cid "github.com/ipfs/go-cid"
+	cbor "github.com/ipfs/go-ipld-cbor"
+	format "github.com/ipfs/go-ipld-format"
+	dag "github.com/ipfs/go-merkledag"
+)
+
+func init() {
+	cbor.RegisterCborType(CarHeader{})
+}
+
+type Store interface {
+	Put(blocks.Block) error
+}
+
+type ReadStore interface {
+	Get(cid.Cid) (blocks.Block, error)
+}
+
+type CarHeader struct {
+	Roots   []cid.Cid
+	Version uint64
+}
+
+type carWriter struct {
+	ds   format.NodeGetter
+	w    io.Writer
+	walk WalkFunc
+}
+
+type WalkFunc func(format.Node) ([]*format.Link, error)
+
+func WriteCar(ctx context.Context, ds format.NodeGetter, roots []cid.Cid, w io.Writer) error {
+	return WriteCarWithWalker(ctx, ds, roots, w, DefaultWalkFunc)
+}
+
+func WriteCarWithWalker(ctx context.Context, ds format.NodeGetter, roots []cid.Cid, w io.Writer, walk WalkFunc) error {
+	h := &CarHeader{
+		Roots:   roots,
+		Version: 1,
+	}
+
+	if err := WriteHeader(h, w); err != nil {
+		return fmt.Errorf("failed to write car header: %s", err)
+	}
+
+	cw := &carWriter{ds: ds, w: w, walk: walk}
+	seen := cid.NewSet()
+	for _, r := range roots {
+		if err := dag.Walk(ctx, cw.enumGetLinks, r, seen.Visit); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func DefaultWalkFunc(nd format.Node) ([]*format.Link, error) {
+	return nd.Links(), nil
+}
+
+func ReadHeader(br *bufio.Reader) (*CarHeader, error) {
+	hb, err := util.LdRead(br)
+	if err != nil {
+		return nil, err
+	}
+
+	var ch CarHeader
+	if err := cbor.DecodeInto(hb, &ch); err != nil {
+		return nil, fmt.Errorf("invalid header: %v", err)
+	}
+
+	return &ch, nil
+}
+
+func WriteHeader(h *CarHeader, w io.Writer) error {
+	hb, err := cbor.DumpObject(h)
+	if err != nil {
+		return err
+	}
+
+	return util.LdWrite(w, hb)
+}
+
+func HeaderSize(h *CarHeader) (uint64, error) {
+	hb, err := cbor.DumpObject(h)
+	if err != nil {
+		return 0, err
+	}
+
+	return util.LdSize(hb), nil
+}
+
+func (cw *carWriter) enumGetLinks(ctx context.Context, c cid.Cid) ([]*format.Link, error) {
+	nd, err := cw.ds.Get(ctx, c)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := cw.writeNode(ctx, nd); err != nil {
+		return nil, err
+	}
+
+	return cw.walk(nd)
+}
+
+func (cw *carWriter) writeNode(ctx context.Context, nd format.Node) error {
+	return util.LdWrite(cw.w, nd.Cid().Bytes(), nd.RawData())
+}
+
+type CarReader struct {
+	br     *bufio.Reader
+	Header *CarHeader
+}
+
+func NewCarReader(r io.Reader) (*CarReader, error) {
+	br := bufio.NewReader(r)
+	ch, err := ReadHeader(br)
+	if err != nil {
+		return nil, err
+	}
+
+	if ch.Version != 1 {
+		return nil, fmt.Errorf("invalid car version: %d", ch.Version)
+	}
+
+	if len(ch.Roots) == 0 {
+		return nil, fmt.Errorf("empty car, no roots")
+	}
+
+	return &CarReader{
+		br:     br,
+		Header: ch,
+	}, nil
+}
+
+func (cr *CarReader) Next() (blocks.Block, error) {
+	c, data, err := util.ReadNode(cr.br)
+	if err != nil {
+		return nil, err
+	}
+
+	hashed, err := c.Prefix().Sum(data)
+	if err != nil {
+		return nil, err
+	}
+
+	if !hashed.Equals(c) {
+		return nil, fmt.Errorf("mismatch in content integrity, name: %s, data: %s", c, hashed)
+	}
+
+	return blocks.NewBlockWithCid(data, c)
+}
+
+type batchStore interface {
+	PutMany([]blocks.Block) error
+}
+
+func LoadCar(s Store, r io.Reader) (*CarHeader, error) {
+	cr, err := NewCarReader(r)
+	if err != nil {
+		return nil, err
+	}
+
+	if bs, ok := s.(batchStore); ok {
+		return loadCarFast(bs, cr)
+	}
+
+	return loadCarSlow(s, cr)
+}
+
+func loadCarFast(s batchStore, cr *CarReader) (*CarHeader, error) {
+	var buf []blocks.Block
+	for {
+		blk, err := cr.Next()
+		if err != nil {
+			if err == io.EOF {
+				if len(buf) > 0 {
+					if err := s.PutMany(buf); err != nil {
+						return nil, err
+					}
+				}
+				return cr.Header, nil
+			}
+			return nil, err
+		}
+
+		buf = append(buf, blk)
+
+		if len(buf) > 1000 {
+			if err := s.PutMany(buf); err != nil {
+				return nil, err
+			}
+			buf = buf[:0]
+		}
+	}
+}
+
+func loadCarSlow(s Store, cr *CarReader) (*CarHeader, error) {
+	for {
+		blk, err := cr.Next()
+		if err != nil {
+			if err == io.EOF {
+				return cr.Header, nil
+			}
+			return nil, err
+		}
+
+		if err := s.Put(blk); err != nil {
+			return nil, err
+		}
+	}
+}

--- a/v2/internal/carv1/car_test.go
+++ b/v2/internal/carv1/car_test.go
@@ -1,0 +1,231 @@
+package carv1
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"io"
+	"strings"
+	"testing"
+
+	cid "github.com/ipfs/go-cid"
+	format "github.com/ipfs/go-ipld-format"
+	dag "github.com/ipfs/go-merkledag"
+	dstest "github.com/ipfs/go-merkledag/test"
+)
+
+func assertAddNodes(t *testing.T, ds format.DAGService, nds ...format.Node) {
+	for _, nd := range nds {
+		if err := ds.Add(context.Background(), nd); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestRoundtrip(t *testing.T) {
+	dserv := dstest.Mock()
+	a := dag.NewRawNode([]byte("aaaa"))
+	b := dag.NewRawNode([]byte("bbbb"))
+	c := dag.NewRawNode([]byte("cccc"))
+
+	nd1 := &dag.ProtoNode{}
+	nd1.AddNodeLink("cat", a)
+
+	nd2 := &dag.ProtoNode{}
+	nd2.AddNodeLink("first", nd1)
+	nd2.AddNodeLink("dog", b)
+
+	nd3 := &dag.ProtoNode{}
+	nd3.AddNodeLink("second", nd2)
+	nd3.AddNodeLink("bear", c)
+
+	assertAddNodes(t, dserv, a, b, c, nd1, nd2, nd3)
+
+	buf := new(bytes.Buffer)
+	if err := WriteCar(context.Background(), dserv, []cid.Cid{nd3.Cid()}, buf); err != nil {
+		t.Fatal(err)
+	}
+
+	bserv := dstest.Bserv()
+	ch, err := LoadCar(bserv.Blockstore(), buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(ch.Roots) != 1 {
+		t.Fatal("should have one root")
+	}
+
+	if !ch.Roots[0].Equals(nd3.Cid()) {
+		t.Fatal("got wrong cid")
+	}
+
+	bs := bserv.Blockstore()
+	for _, nd := range []format.Node{a, b, c, nd1, nd2, nd3} {
+		has, err := bs.Has(nd.Cid())
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !has {
+			t.Fatal("should have cid in blockstore")
+		}
+	}
+}
+
+func TestEOFHandling(t *testing.T) {
+	// fixture is a clean single-block, single-root CAR
+	fixture, err := hex.DecodeString("3aa265726f6f747381d82a58250001711220151fe9e73c6267a7060c6f6c4cca943c236f4b196723489608edb42a8b8fa80b6776657273696f6e012c01711220151fe9e73c6267a7060c6f6c4cca943c236f4b196723489608edb42a8b8fa80ba165646f646779f5")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	load := func(t *testing.T, byts []byte) *CarReader {
+		cr, err := NewCarReader(bytes.NewReader(byts))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		blk, err := cr.Next()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if blk.Cid().String() != "bafyreiavd7u6opdcm6tqmddpnrgmvfb4enxuwglhenejmchnwqvixd5ibm" {
+			t.Fatal("unexpected CID")
+		}
+
+		return cr
+	}
+
+	t.Run("CleanEOF", func(t *testing.T) {
+		cr := load(t, fixture)
+
+		blk, err := cr.Next()
+		if err != io.EOF {
+			t.Fatal("Didn't get expected EOF")
+		}
+		if blk != nil {
+			t.Fatal("EOF returned expected block")
+		}
+	})
+
+	t.Run("BadVarint", func(t *testing.T) {
+		fixtureBadVarint := append(fixture, 160)
+		cr := load(t, fixtureBadVarint)
+
+		blk, err := cr.Next()
+		if err != io.ErrUnexpectedEOF {
+			t.Fatal("Didn't get unexpected EOF")
+		}
+		if blk != nil {
+			t.Fatal("EOF returned unexpected block")
+		}
+	})
+
+	t.Run("TruncatedBlock", func(t *testing.T) {
+		fixtureTruncatedBlock := append(fixture, 100, 0, 0)
+		cr := load(t, fixtureTruncatedBlock)
+
+		blk, err := cr.Next()
+		if err != io.ErrUnexpectedEOF {
+			t.Fatal("Didn't get unexpected EOF")
+		}
+		if blk != nil {
+			t.Fatal("EOF returned unexpected block")
+		}
+	})
+}
+
+func TestBadHeaders(t *testing.T) {
+	testCases := []struct {
+		name   string
+		hex    string
+		errStr string // either the whole error string
+		errPfx string // or just the prefix
+	}{
+		{
+			"{version:2}",
+			"0aa16776657273696f6e02",
+			"invalid car version: 2",
+			"",
+		},
+		{
+			// an unfortunate error because we don't use a pointer
+			"{roots:[baeaaaa3bmjrq]}",
+			"13a165726f6f747381d82a480001000003616263",
+			"invalid car version: 0",
+			"",
+		},
+		{
+			"{version:\"1\",roots:[baeaaaa3bmjrq]}",
+			"1da265726f6f747381d82a4800010000036162636776657273696f6e6131",
+			"", "invalid header: ",
+		},
+		{
+			"{version:1}",
+			"0aa16776657273696f6e01",
+			"empty car, no roots",
+			"",
+		},
+		{
+			"{version:1,roots:{cid:baeaaaa3bmjrq}}",
+			"20a265726f6f7473a163636964d82a4800010000036162636776657273696f6e01",
+			"",
+			"invalid header: ",
+		},
+		{
+			"{version:1,roots:[baeaaaa3bmjrq],blip:true}",
+			"22a364626c6970f565726f6f747381d82a4800010000036162636776657273696f6e01",
+			"",
+			"invalid header: ",
+		},
+		{
+			"[1,[]]",
+			"03820180",
+			"",
+			"invalid header: ",
+		},
+		{
+			// this is an unfortunate error, it'd be nice to catch it better but it's
+			// very unlikely we'd ever see this in practice
+			"null",
+			"01f6",
+			"",
+			"invalid car version: 0",
+		},
+	}
+
+	makeCar := func(t *testing.T, byts string) error {
+		fixture, err := hex.DecodeString(byts)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, err = NewCarReader(bytes.NewReader(fixture))
+		return err
+	}
+
+	t.Run("Sanity check {version:1,roots:[baeaaaa3bmjrq]}", func(t *testing.T) {
+		err := makeCar(t, "1ca265726f6f747381d82a4800010000036162636776657273696f6e01")
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := makeCar(t, tc.hex)
+			if err == nil {
+				t.Fatal("expected error from bad header, didn't get one")
+			}
+			if tc.errStr != "" {
+				if err.Error() != tc.errStr {
+					t.Fatalf("bad error: %v", err)
+				}
+			} else {
+				if !strings.HasPrefix(err.Error(), tc.errPfx) {
+					t.Fatalf("bad error: %v", err)
+				}
+			}
+		})
+	}
+}

--- a/v2/internal/carv1/doc.go
+++ b/v2/internal/carv1/doc.go
@@ -1,0 +1,2 @@
+// Forked from CAR v1 to avoid dependency to ipld-prime 0.9.0 due to outstanding upgrades in filecoin.
+package carv1

--- a/v2/internal/carv1/util/util.go
+++ b/v2/internal/carv1/util/util.go
@@ -1,0 +1,121 @@
+package util
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"io"
+
+	cid "github.com/ipfs/go-cid"
+	mh "github.com/multiformats/go-multihash"
+)
+
+var cidv0Pref = []byte{0x12, 0x20}
+
+type BytesReader interface {
+	io.Reader
+	io.ByteReader
+}
+
+// TODO: this belongs in the go-cid package
+func ReadCid(buf []byte) (cid.Cid, int, error) {
+	if bytes.Equal(buf[:2], cidv0Pref) {
+		c, err := cid.Cast(buf[:34])
+		return c, 34, err
+	}
+
+	br := bytes.NewReader(buf)
+
+	// assume cidv1
+	vers, err := binary.ReadUvarint(br)
+	if err != nil {
+		return cid.Cid{}, 0, err
+	}
+
+	// TODO: the go-cid package allows version 0 here as well
+	if vers != 1 {
+		return cid.Cid{}, 0, fmt.Errorf("invalid cid version number")
+	}
+
+	codec, err := binary.ReadUvarint(br)
+	if err != nil {
+		return cid.Cid{}, 0, err
+	}
+
+	mhr := mh.NewReader(br)
+	h, err := mhr.ReadMultihash()
+	if err != nil {
+		return cid.Cid{}, 0, err
+	}
+
+	return cid.NewCidV1(codec, h), len(buf) - br.Len(), nil
+}
+
+func ReadNode(br *bufio.Reader) (cid.Cid, []byte, error) {
+	data, err := LdRead(br)
+	if err != nil {
+		return cid.Cid{}, nil, err
+	}
+
+	c, n, err := ReadCid(data)
+	if err != nil {
+		return cid.Cid{}, nil, err
+	}
+
+	return c, data[n:], nil
+}
+
+func LdWrite(w io.Writer, d ...[]byte) error {
+	var sum uint64
+	for _, s := range d {
+		sum += uint64(len(s))
+	}
+
+	buf := make([]byte, 8)
+	n := binary.PutUvarint(buf, sum)
+	_, err := w.Write(buf[:n])
+	if err != nil {
+		return err
+	}
+
+	for _, s := range d {
+		_, err = w.Write(s)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func LdSize(d ...[]byte) uint64 {
+	var sum uint64
+	for _, s := range d {
+		sum += uint64(len(s))
+	}
+	buf := make([]byte, 8)
+	n := binary.PutUvarint(buf, sum)
+	return sum + uint64(n)
+}
+
+func LdRead(r *bufio.Reader) ([]byte, error) {
+	if _, err := r.Peek(1); err != nil { // no more blocks, likely clean io.EOF
+		return nil, err
+	}
+
+	l, err := binary.ReadUvarint(r)
+	if err != nil {
+		if err == io.EOF {
+			return nil, io.ErrUnexpectedEOF // don't silently pretend this is a clean EOF
+		}
+		return nil, err
+	}
+
+	buf := make([]byte, l)
+	if _, err := io.ReadFull(r, buf); err != nil {
+		return nil, err
+	}
+
+	return buf, nil
+}

--- a/v2/internal/carv1/util/util_test.go
+++ b/v2/internal/carv1/util/util_test.go
@@ -1,0 +1,27 @@
+package util_test
+
+import (
+	"bytes"
+	"math/rand"
+	"testing"
+
+	"github.com/ipld/go-car/v2/internal/carv1/util"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLdSize(t *testing.T) {
+	for i := 0; i < 5; i++ {
+		var buf bytes.Buffer
+		data := make([][]byte, 5)
+		for j := 0; j < 5; j++ {
+			data[j] = make([]byte, rand.Intn(30))
+			_, err := rand.Read(data[j])
+			require.NoError(t, err)
+		}
+		size := util.LdSize(data...)
+		err := util.LdWrite(&buf, data...)
+		require.NoError(t, err)
+		require.Equal(t, uint64(len(buf.Bytes())), size)
+	}
+}

--- a/v2/reader.go
+++ b/v2/reader.go
@@ -8,7 +8,7 @@ import (
 	internalio "github.com/ipld/go-car/v2/internal/io"
 
 	"github.com/ipfs/go-cid"
-	carv1 "github.com/ipld/go-car"
+	"github.com/ipld/go-car/v2/internal/carv1"
 )
 
 // Reader represents a reader of CAR v2.

--- a/v2/writer.go
+++ b/v2/writer.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/ipfs/go-cid"
 	format "github.com/ipfs/go-ipld-format"
-	carv1 "github.com/ipld/go-car"
 	"github.com/ipld/go-car/v2/index"
+	"github.com/ipld/go-car/v2/internal/carv1"
 )
 
 const bulkPaddingBytesSize = 1024


### PR DESCRIPTION
Remove dependency to CAR v1 go module, because that module depends on
later version of ipld-prime which have not been reflected in filecoin
project.

In the interest of time, we fork the code that v2 needs in v1. This
allows a more efficient implementation of some APIs that accep types
like `bufio.Reader` while helping the filecoin team push ahead with
deliverables without undergoing a big upgrade process.

On the CAR v2 side, this however means that we postpone the
implementation of Selective Car for v2 until filecoin is upgraded its
ipld-prime dependency. This is to avoid implementing an obsolete
selective car API that uses the old ipld-prime API which force user yet
another upgrade.