### PR TITLE
Improve documentation and fix bug in writer

### DIFF
--- a/v2/blockstore/doc.go
+++ b/v2/blockstore/doc.go
@@ -1,0 +1,14 @@
+// package blockstore implements IPFS blockstore interface backed by a CAR file.
+// This package provides two flavours of blockstore: ReadOnly and ReadWrite.
+//
+// The ReadOnly blockstore provides a read-only random access from a given data payload either in
+// unindexed v1 format or indexed/unindexed v2 format:
+// - ReadOnly.ReadOnlyOf can be used to instantiate a new read-only blockstore for a given CAR v1
+//   data payload and an existing index. See index.Generate for index generation from CAR v1
+//   payload.
+// - ReadOnly.OpenReadOnly can be used to instantiate a new read-only blockstore for a given CAR v2
+//   file with automatic index generation if the index is not present in the given file. This
+//   function can optionally attach the index to the given CAR v2 file.
+//
+
+package blockstore

--- a/v2/blockstore/readwrite_test.go
+++ b/v2/blockstore/readwrite_test.go
@@ -62,7 +62,7 @@ func TestBlockstore(t *testing.T) {
 	if err := ingester.Finalize(); err != nil {
 		t.Fatal(err)
 	}
-	carb, err := blockstore.OpenReadOnly(path, true)
+	carb, err := blockstore.OpenReadOnly(path, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/v2/index/doc.go
+++ b/v2/index/doc.go
@@ -1,0 +1,12 @@
+// package index provides indexing functionality for CAR v1 data payload represented as a mapping of
+// CID to offset. This can then be used to implement random access over a CAR v1.
+//
+// Index can be written or read using the following static functions: index.WriteTo and
+// index.ReadFrom.
+//
+// This package also provides functionality to generate an index from a given CAR v1 file using:
+// index.Generate and index.GenerateFromFile
+//
+// In addition to the above, it provides functionality to attach an index to an index-less CAR v2
+// using index.Attach
+package index

--- a/v2/index/errors.go
+++ b/v2/index/errors.go
@@ -3,7 +3,8 @@ package index
 import "errors"
 
 var (
-	// errNotFound is returned for lookups to entries that don't exist
-	errNotFound    = errors.New("not found")
+	// errNotFound signals a record is not found in the index.
+	errNotFound = errors.New("not found")
+	// errUnsupported signals unsupported operation by an index.
 	errUnsupported = errors.New("not supported")
 )

--- a/v2/index/index.go
+++ b/v2/index/index.go
@@ -12,7 +12,7 @@ import (
 	"github.com/ipfs/go-cid"
 )
 
-// Codec table is a first var-int in carbs indexes
+// Codec table is a first var-int in CAR indexes
 const (
 	IndexHashed Codec = iota + 0x300000
 	IndexSorted
@@ -22,11 +22,11 @@ const (
 )
 
 type (
-	// Codec is used as a multicodec identifier for carbs index files
+	// Codec is used as a multicodec identifier for CAR index files
 	Codec int
 
-	// IndexCls is a constructor for an index type
-	IndexCls func() Index
+	// Builder is a constructor for an index type
+	Builder func() Index
 
 	// Record is a pre-processed record of a car item and location.
 	Record struct {
@@ -34,7 +34,7 @@ type (
 		Idx uint64
 	}
 
-	// Index provides an interface for figuring out where in the car a given cid begins
+	// Index provides an interface for looking up byte offset of a given CID.
 	Index interface {
 		Codec() Codec
 		Marshal(w io.Writer) error
@@ -44,8 +44,8 @@ type (
 	}
 )
 
-// IndexAtlas holds known index formats
-var IndexAtlas = map[Codec]IndexCls{
+// BuildersByCodec holds known index formats
+var BuildersByCodec = map[Codec]Builder{
 	IndexHashed:       mkHashed,
 	IndexSorted:       mkSorted,
 	IndexSingleSorted: mkSingleSorted,
@@ -53,9 +53,9 @@ var IndexAtlas = map[Codec]IndexCls{
 	IndexInsertion:    mkInsertion,
 }
 
-// Save writes a generated index into the given `path` as a file with a `.idx` extension.
+// Save writes a generated index into the given `path`.
 func Save(idx Index, path string) error {
-	stream, err := os.OpenFile(path+".idx", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o640)
+	stream, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o640)
 	if err != nil {
 		return err
 	}
@@ -74,28 +74,34 @@ func Attach(path string, idx Index, offset uint64) error {
 	return WriteTo(idx, indexWriter)
 }
 
-func WriteTo(i Index, w io.Writer) error {
+// WriteTo writes the given idx into w.
+// The written bytes include the index encoding.
+// This can then be read back using index.ReadFrom
+func WriteTo(idx Index, w io.Writer) error {
 	buf := make([]byte, binary.MaxVarintLen64)
-	b := binary.PutUvarint(buf, uint64(i.Codec()))
+	b := binary.PutUvarint(buf, uint64(idx.Codec()))
 	if _, err := w.Write(buf[:b]); err != nil {
 		return err
 	}
-	return i.Marshal(w)
+	return idx.Marshal(w)
 }
 
-func ReadFrom(uar io.Reader) (Index, error) {
-	reader := bufio.NewReader(uar)
+// ReadFrom reads index from r.
+// The reader decodes the index by reading the first byte to interpret the encoding.
+// Returns error if the encoding is not known.
+func ReadFrom(r io.Reader) (Index, error) {
+	reader := bufio.NewReader(r)
 	codec, err := binary.ReadUvarint(reader)
 	if err != nil {
 		return nil, err
 	}
-	idx, ok := IndexAtlas[Codec(codec)]
+	builder, ok := BuildersByCodec[Codec(codec)]
 	if !ok {
 		return nil, fmt.Errorf("unknown codec: %d", codec)
 	}
-	idxInst := idx()
-	if err := idxInst.Unmarshal(reader); err != nil {
+	idx := builder()
+	if err := idx.Unmarshal(reader); err != nil {
 		return nil, err
 	}
-	return idxInst, nil
+	return idx, nil
 }

--- a/v2/index/insertionindex.go
+++ b/v2/index/insertionindex.go
@@ -125,7 +125,7 @@ func mkInsertion() Index {
 
 // Flatten returns a 'indexsorted' formatted index for more efficient subsequent loading
 func (ii *InsertionIndex) Flatten() (Index, error) {
-	si := IndexAtlas[IndexSorted]()
+	si := BuildersByCodec[IndexSorted]()
 	rcrds := make([]Record, ii.items.Len())
 
 	idx := 0

--- a/v2/internal/carbs/util/hydrate.go
+++ b/v2/internal/carbs/util/hydrate.go
@@ -10,18 +10,10 @@ import (
 
 func main() {
 	if len(os.Args) < 2 {
-		fmt.Printf("Usage: hydrate <file.car> [codec]\n")
+		fmt.Printf("Usage: hydrate <file.car>\n")
 		return
 	}
 	db := os.Args[1]
-	codec := index.IndexSorted
-	if len(os.Args) == 3 {
-		if os.Args[2] == "Hash" {
-			codec = index.IndexHashed
-		} else if os.Args[2] == "GobHash" {
-			codec = index.IndexGobHashed
-		}
-	}
 
 	dbBacking, err := mmap.Open(db)
 	if err != nil {
@@ -29,7 +21,7 @@ func main() {
 		return
 	}
 
-	idx, err := index.Generate(dbBacking, codec)
+	idx, err := index.Generate(dbBacking)
 	if err != nil {
 		fmt.Printf("Error generating index: %v\n", err)
 		return

--- a/v2/reader.go
+++ b/v2/reader.go
@@ -70,7 +70,7 @@ func (r *Reader) CarV1Reader() *io.SectionReader { // TODO consider returning io
 	return io.NewSectionReader(r.r, int64(r.Header.CarV1Offset), int64(r.Header.CarV1Size))
 }
 
-// IndexReader provides an io.Reader containing the carbs.Index of this CAR v2.
+// IndexReader provides an io.Reader containing the index of this CAR v2.
 func (r *Reader) IndexReader() io.Reader { // TODO consider returning io.Reader+ReaderAt in a custom interface
 	return internalio.NewOffsetReader(r.r, int64(r.Header.IndexOffset))
 }


### PR DESCRIPTION
Add documentation where it is sparse to help folks learn how to use the
library easier.

Unexport the ability to select codec, until we decide what codec we want
to expose. Fix all encodings of index to `IndexSorted`.

Fix a bug in writer where index is written by direct marshalling instead
of index.WriteTo which includes index codec.

Refactor in places for better readability.