### PR TITLE
Replace `binary.Put/ReadUvarint` with `go-varint`

### DIFF
--- a/v2/blockstore/readonly.go
+++ b/v2/blockstore/readonly.go
@@ -4,11 +4,12 @@ import (
 	"bufio"
 	"bytes"
 	"context"
-	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
 	"sync"
+
+	"github.com/multiformats/go-varint"
 
 	blocks "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-cid"
@@ -103,7 +104,7 @@ func (b *ReadOnly) Has(key cid.Cid) (bool, error) {
 		return false, err
 	}
 	uar := internalio.NewOffsetReader(b.backing, int64(offset))
-	_, err = binary.ReadUvarint(uar)
+	_, err = varint.ReadUvarint(uar)
 	if err != nil {
 		return false, err
 	}
@@ -143,7 +144,7 @@ func (b *ReadOnly) GetSize(key cid.Cid) (int, error) {
 	if err != nil {
 		return -1, err
 	}
-	l, err := binary.ReadUvarint(internalio.NewOffsetReader(b.backing, int64(idx)))
+	l, err := varint.ReadUvarint(internalio.NewOffsetReader(b.backing, int64(idx)))
 	if err != nil {
 		return -1, blockstore.ErrNotFound
 	}
@@ -193,7 +194,7 @@ func (b *ReadOnly) AllKeysChan(ctx context.Context) (<-chan cid.Cid, error) {
 
 		rdr := internalio.NewOffsetReader(b.backing, int64(offset))
 		for {
-			l, err := binary.ReadUvarint(rdr)
+			l, err := varint.ReadUvarint(rdr)
 			if err != nil {
 				return // TODO: log this error
 			}

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/ipfs/go-merkledag v0.3.2
 	github.com/mattn/go-colorable v0.1.8 // indirect
 	github.com/multiformats/go-multihash v0.0.15
+	github.com/multiformats/go-varint v0.0.6
 	github.com/petar/GoLLRB v0.0.0-20210522233825-ae3b015fd3e9
 	github.com/stretchr/testify v1.7.0
 	github.com/whyrusleeping/cbor v0.0.0-20171005072247-63513f603b11

--- a/v2/index/generator.go
+++ b/v2/index/generator.go
@@ -2,10 +2,11 @@ package index
 
 import (
 	"bufio"
-	"encoding/binary"
 	"fmt"
 	"io"
 	"os"
+
+	"github.com/multiformats/go-varint"
 
 	"github.com/ipfs/go-cid"
 	"github.com/ipld/go-car/v2/internal/carv1"
@@ -51,7 +52,7 @@ func Generate(v1 io.ReadSeeker) (Index, error) {
 	for {
 		// Grab the length of the frame.
 		// Note that ReadUvarint wants a ByteReader.
-		length, err := binary.ReadUvarint(readSeekerPlusByte{v1})
+		length, err := varint.ReadUvarint(readSeekerPlusByte{v1})
 		if err != nil {
 			if err == io.EOF {
 				break

--- a/v2/index/index.go
+++ b/v2/index/index.go
@@ -2,10 +2,11 @@ package index
 
 import (
 	"bufio"
-	"encoding/binary"
 	"fmt"
 	"io"
 	"os"
+
+	"github.com/multiformats/go-varint"
 
 	internalio "github.com/ipld/go-car/v2/internal/io"
 
@@ -82,9 +83,8 @@ func Attach(path string, idx Index, offset uint64) error {
 // The written bytes include the index encoding.
 // This can then be read back using index.ReadFrom
 func WriteTo(idx Index, w io.Writer) error {
-	buf := make([]byte, binary.MaxVarintLen64)
-	b := binary.PutUvarint(buf, uint64(idx.Codec()))
-	if _, err := w.Write(buf[:b]); err != nil {
+	b := varint.ToUvarint(uint64(idx.Codec()))
+	if _, err := w.Write(b); err != nil {
 		return err
 	}
 	return idx.Marshal(w)
@@ -95,7 +95,7 @@ func WriteTo(idx Index, w io.Writer) error {
 // Returns error if the encoding is not known.
 func ReadFrom(r io.Reader) (Index, error) {
 	reader := bufio.NewReader(r)
-	codec, err := binary.ReadUvarint(reader)
+	codec, err := varint.ReadUvarint(reader)
 	if err != nil {
 		return nil, err
 	}

--- a/v2/index/index.go
+++ b/v2/index/index.go
@@ -2,6 +2,7 @@ package index
 
 import (
 	"bufio"
+	"encoding/binary"
 	"fmt"
 	"io"
 	"os"
@@ -83,8 +84,9 @@ func Attach(path string, idx Index, offset uint64) error {
 // The written bytes include the index encoding.
 // This can then be read back using index.ReadFrom
 func WriteTo(idx Index, w io.Writer) error {
-	b := varint.ToUvarint(uint64(idx.Codec()))
-	if _, err := w.Write(b); err != nil {
+	buf := make([]byte, binary.MaxVarintLen64)
+	b := varint.PutUvarint(buf, uint64(idx.Codec()))
+	if _, err := w.Write(buf[:b]); err != nil {
 		return err
 	}
 	return idx.Marshal(w)

--- a/v2/internal/carv1/util/util.go
+++ b/v2/internal/carv1/util/util.go
@@ -34,7 +34,9 @@ func LdWrite(w io.Writer, d ...[]byte) error {
 		sum += uint64(len(s))
 	}
 
-	_, err := w.Write(varint.ToUvarint(sum))
+	buf := make([]byte, 8)
+	n := varint.PutUvarint(buf, sum)
+	_, err := w.Write(buf[:n])
 	if err != nil {
 		return err
 	}

--- a/v2/internal/carv1/util/util.go
+++ b/v2/internal/carv1/util/util.go
@@ -2,8 +2,9 @@ package util
 
 import (
 	"bufio"
-	"encoding/binary"
 	"io"
+
+	"github.com/multiformats/go-varint"
 
 	cid "github.com/ipfs/go-cid"
 )
@@ -33,9 +34,7 @@ func LdWrite(w io.Writer, d ...[]byte) error {
 		sum += uint64(len(s))
 	}
 
-	buf := make([]byte, 8)
-	n := binary.PutUvarint(buf, sum)
-	_, err := w.Write(buf[:n])
+	_, err := w.Write(varint.ToUvarint(sum))
 	if err != nil {
 		return err
 	}
@@ -55,9 +54,8 @@ func LdSize(d ...[]byte) uint64 {
 	for _, s := range d {
 		sum += uint64(len(s))
 	}
-	buf := make([]byte, 8)
-	n := binary.PutUvarint(buf, sum)
-	return sum + uint64(n)
+	s := varint.UvarintSize(sum)
+	return sum + uint64(s)
 }
 
 func LdRead(r *bufio.Reader) ([]byte, error) {
@@ -65,7 +63,7 @@ func LdRead(r *bufio.Reader) ([]byte, error) {
 		return nil, err
 	}
 
-	l, err := binary.ReadUvarint(r)
+	l, err := varint.ReadUvarint(r)
 	if err != nil {
 		if err == io.EOF {
 			return nil, io.ErrUnexpectedEOF // don't silently pretend this is a clean EOF


### PR DESCRIPTION
To guarantee minimal encoding.

Fixes #135