### PR TITLE
Implement read or generate index from CAR accepting v1 or v2

### DIFF
--- a/v2/reader.go
+++ b/v2/reader.go
@@ -129,12 +129,12 @@ var _ io.ReaderAt = (*readSeekerAt)(nil)
 
 type readSeekerAt struct {
 	rs io.ReadSeeker
-	mu sync.RWMutex
+	mu sync.Mutex
 }
 
 func (rsa *readSeekerAt) ReadAt(p []byte, off int64) (n int, err error) {
-	rsa.mu.RLock()
-	defer rsa.mu.RUnlock()
+	rsa.mu.Lock()
+	defer rsa.mu.Unlock()
 	if _, err := rsa.rs.Seek(off, io.SeekStart); err != nil {
 		return 0, err
 	}

--- a/v2/reader.go
+++ b/v2/reader.go
@@ -4,6 +4,9 @@ import (
 	"bufio"
 	"fmt"
 	"io"
+	"sync"
+
+	"github.com/ipld/go-car/v2/index"
 
 	internalio "github.com/ipld/go-car/v2/internal/io"
 
@@ -120,4 +123,63 @@ func ReadVersion(r io.Reader) (version uint64, err error) {
 		return
 	}
 	return header.Version, nil
+}
+
+var _ io.ReaderAt = (*readSeekerAt)(nil)
+
+type readSeekerAt struct {
+	rs io.ReadSeeker
+	mu sync.RWMutex
+}
+
+func (rsa *readSeekerAt) ReadAt(p []byte, off int64) (n int, err error) {
+	rsa.mu.RLock()
+	defer rsa.mu.RUnlock()
+	if _, err := rsa.rs.Seek(off, io.SeekStart); err != nil {
+		return 0, err
+	}
+	return rsa.rs.Read(p)
+}
+
+// ReadOrGenerateIndex accepts both CAR v1 and v2 format, and reads or generates an index for it.
+// When the given reader is in CAR v1 format an index is always generated.
+// For a payload in CAR v2 format, an index is only generated if Header.HasIndex returns false.
+// An error is returned for all other formats, i.e. versions other than 1 or 2.
+//
+// Note, the returned index lives entirely in memory and will not depend on the
+// given reader to fulfill index lookup.
+func ReadOrGenerateIndex(rs io.ReadSeeker) (index.Index, error) {
+	// Seek to the beginning of the reader in order to read version.
+	if _, err := rs.Seek(0, io.SeekStart); err != nil {
+		return nil, err
+	}
+	// Read version.
+	version, err := ReadVersion(rs)
+	if err != nil {
+		return nil, err
+	}
+	// Seek to the begining, since reading the version changes the reader's offset.
+	if _, err := rs.Seek(0, io.SeekStart); err != nil {
+		return nil, err
+	}
+
+	switch version {
+	case 1:
+		// Simply generate the index, since there can't be a pre-existing one.
+		return index.Generate(rs)
+	case 2:
+		// Read CAR v2 format
+		v2r, err := NewReader(&readSeekerAt{rs: rs})
+		if err != nil {
+			return nil, err
+		}
+		// If index is present, then no need to generate; decode and return it.
+		if v2r.Header.HasIndex() {
+			return index.ReadFrom(v2r.IndexReader())
+		}
+		// Otherwise, generate index from CAR v1 payload wrapped within CAR v2 format.
+		return index.Generate(v2r.CarV1Reader())
+	default:
+		return nil, fmt.Errorf("unknown version %v", version)
+	}
 }

--- a/v2/reader_test.go
+++ b/v2/reader_test.go
@@ -1,0 +1,67 @@
+package car
+
+import (
+	"github.com/ipld/go-car/v2/index"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"os"
+	"testing"
+)
+
+func TestReadOrGenerateIndex(t *testing.T) {
+	tests := []struct {
+		name        string
+		carPath     string
+		wantIndexer func(t *testing.T) index.Index
+		wantErr     bool
+	}{
+		{
+			"CarV1IsIndexedAsExpected",
+			"testdata/sample-v1.car",
+			func(t *testing.T) index.Index {
+				v1, err := os.Open("testdata/sample-v1.car")
+				require.NoError(t, err)
+				defer v1.Close()
+				want, err := index.Generate(v1)
+				require.NoError(t, err)
+				return want
+			},
+			false,
+		},
+		{
+			"CarV2WithIndexIsReturnedAsExpected",
+			"testdata/sample-v1.car",
+			func(t *testing.T) index.Index {
+				v2, err := os.Open("testdata/sample-wrapped-v2.car")
+				require.NoError(t, err)
+				defer v2.Close()
+				reader, err := NewReader(v2)
+				require.NoError(t, err)
+				want, err := index.ReadFrom(reader.IndexReader())
+				require.NoError(t, err)
+				return want
+			},
+			false,
+		},
+		{
+			"CarOtherThanV1OrV2IsError",
+			"testdata/sample-rootless-v42.car",
+			func(t *testing.T) index.Index { return nil },
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			carFile, err := os.Open(tt.carPath)
+			require.NoError(t, err)
+			t.Cleanup(func() { assert.NoError(t, carFile.Close()) })
+			got, err := ReadOrGenerateIndex(carFile)
+			if tt.wantErr {
+				require.Error(t, err)
+			}
+			want := tt.wantIndexer(t)
+			require.Equal(t, want, got)
+		})
+	}
+}

--- a/v2/testdata/sample-rootless-v42.car
+++ b/v2/testdata/sample-rootless-v42.car
@@ -1,0 +1,1 @@
+¢erootsögversion*


### PR DESCRIPTION
A user has to undergo a lot of boilerplate code to generate or get an
index where there is a CAR file, the version for which is unknown.
Provide a function that accepts either v1 or v2 payload and reads the
index if present, otherwise generates it for the user. The generated
index lives entirely in memory and will not depend on the given
`io.ReadSeeker` to lookup indices.

Implement tests that check index is returned for v1 or v2 files. Add a
sample file with an imaginary version of 42 for testing purposes to
assert that the indexing function will error if the given file is not v1
or v2.

Fixes https://github.com/ipld/go-car/issues/143