### PR TITLE
Fix bug in ReadOnly blockstore GetSize

### DIFF
--- a/v2/blockstore/readonly.go
+++ b/v2/blockstore/readonly.go
@@ -189,19 +189,19 @@ func (b *ReadOnly) GetSize(key cid.Cid) (int, error) {
 	if err != nil {
 		return -1, err
 	}
-	l, err := varint.ReadUvarint(internalio.NewOffsetReadSeeker(b.backing, int64(idx)))
+	rdr := internalio.NewOffsetReadSeeker(b.backing, int64(idx))
+	frameLen, err := varint.ReadUvarint(rdr)
 	if err != nil {
 		return -1, blockstore.ErrNotFound
 	}
-	_, c, err := cid.CidFromReader(internalio.NewOffsetReadSeeker(b.backing, int64(idx+l)))
+	cidLen, readCid, err := cid.CidFromReader(rdr)
 	if err != nil {
 		return 0, err
 	}
-	if !c.Equals(key) {
+	if !readCid.Equals(key) {
 		return -1, blockstore.ErrNotFound
 	}
-	// get cid. validate.
-	return int(l), err
+	return int(frameLen) - cidLen, err
 }
 
 // Put is not supported and always returns an error.

--- a/v2/blockstore/readonly_test.go
+++ b/v2/blockstore/readonly_test.go
@@ -1,0 +1,43 @@
+package blockstore
+
+import (
+	"io"
+	"os"
+	"testing"
+
+	"github.com/ipld/go-car/v2/internal/carv1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadOnlyGetSize(t *testing.T) {
+	carv1Path := "testdata/test.car"
+	subject, err := OpenReadOnly(carv1Path)
+	t.Cleanup(func() { subject.Close() })
+	require.NoError(t, err)
+
+	f, err := os.Open(carv1Path)
+	require.NoError(t, err)
+	t.Cleanup(func() { f.Close() })
+	v1r, err := carv1.NewCarReader(f)
+	require.NoError(t, err)
+	for {
+		wantBlock, err := v1r.Next()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+
+		key := wantBlock.Cid()
+
+		// Assert returned size matches the block.RawData length.
+		getSize, err := subject.GetSize(key)
+		wantSize := len(wantBlock.RawData())
+		require.NoError(t, err)
+		require.Equal(t, wantSize, getSize)
+
+		// While at it test blocks are as expected.
+		gotBlock, err := subject.Get(key)
+		require.NoError(t, err)
+		require.Equal(t, wantBlock, gotBlock)
+	}
+}


### PR DESCRIPTION
Fix a bug where the returned size in `ReadOnly.GetSize` blockstore was
incorrect and the CID was being read from the wrong offset.

Implement tests to assert returned size matches the block raw data size.

Fixes #133