### PR TITLE
Remove redundant seek before read or generate index

### DIFF
--- a/v2/reader.go
+++ b/v2/reader.go
@@ -149,10 +149,6 @@ func (rsa *readSeekerAt) ReadAt(p []byte, off int64) (n int, err error) {
 // Note, the returned index lives entirely in memory and will not depend on the
 // given reader to fulfill index lookup.
 func ReadOrGenerateIndex(rs io.ReadSeeker) (index.Index, error) {
-	// Seek to the beginning of the reader in order to read version.
-	if _, err := rs.Seek(0, io.SeekStart); err != nil {
-		return nil, err
-	}
 	// Read version.
 	version, err := ReadVersion(rs)
 	if err != nil {


### PR DESCRIPTION
Assume the read seeker passed in is seeked to the beginning of CAR
payload. This is both for consistency of API and avoid unnecessary
seeks when the reader may already be at the right place.

Relates to https://github.com/ipld/go-car/commit/ff72fdd8443ea53256f07dd3acb5d7f7bf665f6f#r53411220