### PR TITLE
Address review comments on resumption

### DIFF
--- a/v2/internal/carv1/car.go
+++ b/v2/internal/carv1/car.go
@@ -210,11 +210,13 @@ func loadCarSlow(s Store, cr *CarReader) (*CarHeader, error) {
 	}
 }
 
-// Equals checks whether two headers are equal.
-// Two headers are considered equal if:
+// Matches checks whether two headers match.
+// Two headers are considered matching if:
 //   1. They have the same version number, and
 //   2. They contain the same root CIDs in any order.
-func (h CarHeader) Equals(other CarHeader) bool {
+// Note, this function explicitly ignores the order of roots.
+// If order of roots matter use reflect.DeepEqual instead.
+func (h CarHeader) Matches(other CarHeader) bool {
 	if h.Version != other.Version {
 		return false
 	}
@@ -229,6 +231,7 @@ func (h CarHeader) Equals(other CarHeader) bool {
 	}
 
 	// Check other contains all roots.
+	// TODO: should this be optimised for cases where the number of roots are large since it has O(N^2) complexity?
 	for _, r := range h.Roots {
 		if !other.containsRoot(r) {
 			return false

--- a/v2/internal/carv1/car_test.go
+++ b/v2/internal/carv1/car_test.go
@@ -232,7 +232,7 @@ func TestBadHeaders(t *testing.T) {
 	}
 }
 
-func TestCarHeaderEquals(t *testing.T) {
+func TestCarHeaderMatchess(t *testing.T) {
 	oneCid := dag.NewRawNode([]byte("fish")).Cid()
 	anotherCid := dag.NewRawNode([]byte("lobster")).Cid()
 	tests := []struct {
@@ -242,49 +242,49 @@ func TestCarHeaderEquals(t *testing.T) {
 		want  bool
 	}{
 		{
-			"SameVersionNilRootsIsEqual",
+			"SameVersionNilRootsIsMatching",
 			CarHeader{nil, 1},
 			CarHeader{nil, 1},
 			true,
 		},
 		{
-			"SameVersionEmptyRootsIsEqual",
+			"SameVersionEmptyRootsIsMatching",
 			CarHeader{[]cid.Cid{}, 1},
 			CarHeader{[]cid.Cid{}, 1},
 			true,
 		},
 		{
-			"SameVersionNonEmptySameRootsIsEqual",
+			"SameVersionNonEmptySameRootsIsMatching",
 			CarHeader{[]cid.Cid{oneCid}, 1},
 			CarHeader{[]cid.Cid{oneCid}, 1},
 			true,
 		},
 		{
-			"SameVersionNonEmptySameRootsInDifferentOrderIsEqual",
+			"SameVersionNonEmptySameRootsInDifferentOrderIsMatching",
 			CarHeader{[]cid.Cid{oneCid, anotherCid}, 1},
 			CarHeader{[]cid.Cid{anotherCid, oneCid}, 1},
 			true,
 		},
 		{
-			"SameVersionDifferentRootsIsNotEqual",
+			"SameVersionDifferentRootsIsNotMatching",
 			CarHeader{[]cid.Cid{oneCid}, 1},
 			CarHeader{[]cid.Cid{anotherCid}, 1},
 			false,
 		},
 		{
-			"DifferentVersionDifferentRootsIsNotEqual",
+			"DifferentVersionDifferentRootsIsNotMatching",
 			CarHeader{[]cid.Cid{oneCid}, 0},
 			CarHeader{[]cid.Cid{anotherCid}, 1},
 			false,
 		},
 		{
-			"MismatchingVersionIsNotEqual",
+			"MismatchingVersionIsNotMatching",
 			CarHeader{nil, 0},
 			CarHeader{nil, 1},
 			false,
 		},
 		{
-			"ZeroValueHeadersAreEqual",
+			"ZeroValueHeadersAreMatching",
 			CarHeader{},
 			CarHeader{},
 			true,
@@ -292,8 +292,8 @@ func TestCarHeaderEquals(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := tt.one.Equals(tt.other)
-			require.Equal(t, tt.want, got, "Equals() = %v, want %v", got, tt.want)
+			got := tt.one.Matches(tt.other)
+			require.Equal(t, tt.want, got, "Matches() = %v, want %v", got, tt.want)
 		})
 	}
 }


### PR DESCRIPTION

* Use the file already open to get the stats for resumption purposes. On
getting the stats, because the open flag contains `os.O_CREATE` check 
the size of the file as a way to determine wheter we should attempt 
resumption or not. In practice this is the same as the code that 
explicitly differentiates from non-existing files, since file existence 
doesn't matter here; the key thing is the file content. Plus this also 
avoids unnecessary errors where the files exists but is empty.

* Add TODOs in places to consider enabling deduplication by default and 
optimise computational complexity of roots check. Note, explicitly 
enable deduplication by default in a separate PR so that the change is
clearly communicated to dependant clients in case it causes any
unintended side-effects.

* Rename `Equals` to `Matches` to avoid confusion about what it does.


Relates to:
- https://github.com/ipld/go-car/pull/147#discussion_r668587909
- https://github.com/ipld/go-car/pull/147#discussion_r668603050
- https://github.com/ipld/go-car/pull/147#discussion_r668609927