### PR TITLE
Index error found should return block not found

### DIFF
--- a/v2/blockstore/readonly.go
+++ b/v2/blockstore/readonly.go
@@ -166,8 +166,9 @@ func (b *ReadOnly) Get(key cid.Cid) (blocks.Block, error) {
 	defer b.mu.RUnlock()
 
 	offset, err := b.idx.Get(key)
+	// TODO Improve error handling; not all errors mean NotFound.
 	if err != nil {
-		return nil, err
+		return nil, blockstore.ErrNotFound
 	}
 	entry, data, err := b.readBlock(int64(offset))
 	if err != nil {


### PR DESCRIPTION
There's blockstore dependent code in our libraries that depends on this particular error if a block does NOT exist.