### PR TITLE
Unexport unused `Writer` API until it is re-implemented

### DIFF
--- a/v2/writer_test.go
+++ b/v2/writer_test.go
@@ -60,7 +60,7 @@ func TestPadding_WriteTo(t *testing.T) {
 func TestNewWriter(t *testing.T) {
 	dagService := dstest.Mock()
 	wantRoots := generateRootCid(t, dagService)
-	writer := NewWriter(context.Background(), dagService, wantRoots)
+	writer := newWriter(context.Background(), dagService, wantRoots)
 	assert.Equal(t, wantRoots, writer.roots)
 }
 


### PR DESCRIPTION
Unexport the CARv2 writer API until it is reimplemented using WriterAt
or WriteSeeker to be more efficient. This API is not used anyway and we
can postpone releasing it until SelectiveCar writer API is figured out.
For now we unexport it to carry on with interface finalization and alpha
release.