### PR TITLE
Enable deduplication by CID in `ReadWrite` blockstore by default

### DIFF
--- a/v2/blockstore/readwrite_test.go
+++ b/v2/blockstore/readwrite_test.go
@@ -104,13 +104,13 @@ func TestBlockstorePutSameHashes(t *testing.T) {
 	tdir := t.TempDir()
 	wbs, err := blockstore.NewReadWrite(
 		filepath.Join(tdir, "readwrite.car"), nil,
+		blockstore.WithDisableCidDeduplication,
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() { wbs.Finalize() })
 
 	wbsd, err := blockstore.NewReadWrite(
 		filepath.Join(tdir, "readwrite-dedup.car"), nil,
-		blockstore.WithCidDeduplication,
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() { wbsd.Finalize() })


### PR DESCRIPTION
Enable the deduplication by CID in `ReadWrite` blockstore by default,
since it is the typical and common usecase across current usage
patterns.