### PR TITLE
Improve test coverage for `ReadWrite` blockstore

### DIFF
--- a/car.go
+++ b/car.go
@@ -10,7 +10,7 @@ import (
 	cid "github.com/ipfs/go-cid"
 	cbor "github.com/ipfs/go-ipld-cbor"
 	format "github.com/ipfs/go-ipld-format"
-	dag "github.com/ipfs/go-merkledag"
+	"github.com/ipfs/go-merkledag"
 
 	util "github.com/ipld/go-car/util"
 )
@@ -58,7 +58,7 @@ func WriteCarWithWalker(ctx context.Context, ds format.NodeGetter, roots []cid.C
 	cw := &carWriter{ds: ds, w: w, walk: walk}
 	seen := cid.NewSet()
 	for _, r := range roots {
-		if err := dag.Walk(ctx, cw.enumGetLinks, r, seen.Visit); err != nil {
+		if err := merkledag.Walk(ctx, cw.enumGetLinks, r, seen.Visit); err != nil {
 			return err
 		}
 	}

--- a/car_test.go
+++ b/car_test.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 	"testing"
 
-	cid "github.com/ipfs/go-cid"
+	"github.com/ipfs/go-cid"
 	format "github.com/ipfs/go-ipld-format"
-	dag "github.com/ipfs/go-merkledag"
+	"github.com/ipfs/go-merkledag"
 	dstest "github.com/ipfs/go-merkledag/test"
 	basicnode "github.com/ipld/go-ipld-prime/node/basic"
 	"github.com/ipld/go-ipld-prime/traversal/selector"
@@ -28,18 +28,18 @@ func assertAddNodes(t *testing.T, ds format.DAGService, nds ...format.Node) {
 
 func TestRoundtrip(t *testing.T) {
 	dserv := dstest.Mock()
-	a := dag.NewRawNode([]byte("aaaa"))
-	b := dag.NewRawNode([]byte("bbbb"))
-	c := dag.NewRawNode([]byte("cccc"))
+	a := merkledag.NewRawNode([]byte("aaaa"))
+	b := merkledag.NewRawNode([]byte("bbbb"))
+	c := merkledag.NewRawNode([]byte("cccc"))
 
-	nd1 := &dag.ProtoNode{}
+	nd1 := &merkledag.ProtoNode{}
 	nd1.AddNodeLink("cat", a)
 
-	nd2 := &dag.ProtoNode{}
+	nd2 := &merkledag.ProtoNode{}
 	nd2.AddNodeLink("first", nd1)
 	nd2.AddNodeLink("dog", b)
 
-	nd3 := &dag.ProtoNode{}
+	nd3 := &merkledag.ProtoNode{}
 	nd3.AddNodeLink("second", nd2)
 	nd3.AddNodeLink("bear", c)
 
@@ -80,20 +80,20 @@ func TestRoundtrip(t *testing.T) {
 func TestRoundtripSelective(t *testing.T) {
 	sourceBserv := dstest.Bserv()
 	sourceBs := sourceBserv.Blockstore()
-	dserv := dag.NewDAGService(sourceBserv)
-	a := dag.NewRawNode([]byte("aaaa"))
-	b := dag.NewRawNode([]byte("bbbb"))
-	c := dag.NewRawNode([]byte("cccc"))
+	dserv := merkledag.NewDAGService(sourceBserv)
+	a := merkledag.NewRawNode([]byte("aaaa"))
+	b := merkledag.NewRawNode([]byte("bbbb"))
+	c := merkledag.NewRawNode([]byte("cccc"))
 
-	nd1 := &dag.ProtoNode{}
+	nd1 := &merkledag.ProtoNode{}
 	nd1.AddNodeLink("cat", a)
 
-	nd2 := &dag.ProtoNode{}
+	nd2 := &merkledag.ProtoNode{}
 	nd2.AddNodeLink("first", nd1)
 	nd2.AddNodeLink("dog", b)
 	nd2.AddNodeLink("repeat", nd1)
 
-	nd3 := &dag.ProtoNode{}
+	nd3 := &merkledag.ProtoNode{}
 	nd3.AddNodeLink("second", nd2)
 	nd3.AddNodeLink("bear", c)
 
@@ -106,7 +106,7 @@ func TestRoundtripSelective(t *testing.T) {
 	// this selector starts at n3, and traverses a link at index 1 (nd2, the second link, zero indexed)
 	// it then recursively traverses all of its children
 	// the only node skipped is 'c' -- link at index 0 immediately below nd3
-	// the purpose is simply to show we are not writing the entire dag underneath
+	// the purpose is simply to show we are not writing the entire merkledag underneath
 	// nd3
 	selector := ssb.ExploreFields(func(efsb builder.ExploreFieldsSpecBuilder) {
 		efsb.Insert("Links",

--- a/v2/blockstore/readwrite.go
+++ b/v2/blockstore/readwrite.go
@@ -184,11 +184,11 @@ func (b *ReadWrite) resumeWithRoots(roots []cid.Cid) error {
 	if err == nil && headerInFile.CarV1Offset != 0 {
 		if headerInFile.CarV1Offset != b.header.CarV1Offset {
 			// Assert that the padding on file matches the given WithCarV1Padding option.
-			gotPadding := headerInFile.CarV1Offset - carv2.PragmaSize - carv2.HeaderSize
-			wantPadding := b.header.CarV1Offset - carv2.PragmaSize - carv2.HeaderSize
+			wantPadding := headerInFile.CarV1Offset - carv2.PragmaSize - carv2.HeaderSize
+			gotPadding := b.header.CarV1Offset - carv2.PragmaSize - carv2.HeaderSize
 			return fmt.Errorf(
 				"cannot resume from file with mismatched CARv1 offset; "+
-					"`WithCarV1Padding` option must match the padding on file."+
+					"`WithCarV1Padding` option must match the padding on file. "+
 					"Expected padding value of %v but got %v", wantPadding, gotPadding,
 			)
 		} else if headerInFile.CarV1Size != 0 {
@@ -330,7 +330,6 @@ func (b *ReadWrite) Finalize() error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	// TODO check if add index option is set and don't write the index then set index offset to zero.
-	// TODO see if folks need to continue reading from a finalized blockstore, if so return ReadOnly blockstore here.
 	b.header = b.header.WithCarV1Size(uint64(b.carV1Writer.Position()))
 	defer b.Close()
 
@@ -368,4 +367,10 @@ func (b *ReadWrite) GetSize(key cid.Cid) (int, error) {
 	b.panicIfFinalized()
 
 	return b.ReadOnly.GetSize(key)
+}
+
+func (b *ReadWrite) HashOnRead(h bool) {
+	b.panicIfFinalized()
+
+	b.ReadOnly.HashOnRead(h)
 }

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/ipfs/go-ipld-cbor v0.0.5
 	github.com/ipfs/go-ipld-format v0.2.0
 	github.com/ipfs/go-merkledag v0.3.2
+	github.com/klauspost/cpuid/v2 v2.0.8 // indirect
 	github.com/mattn/go-colorable v0.1.8 // indirect
 	github.com/multiformats/go-multicodec v0.2.1-0.20210713081508-b421db6850ae
 	github.com/multiformats/go-multihash v0.0.15
@@ -16,6 +17,7 @@ require (
 	github.com/petar/GoLLRB v0.0.0-20210522233825-ae3b015fd3e9
 	github.com/stretchr/testify v1.7.0
 	github.com/whyrusleeping/cbor v0.0.0-20171005072247-63513f603b11
+	golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97 // indirect
 	golang.org/x/exp v0.0.0-20210615023648-acb5c1269671
-	golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57 // indirect
+	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c // indirect
 )

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -256,8 +256,9 @@ github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvW
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kkdai/bstream v0.0.0-20161212061736-f391b8402d23/go.mod h1:J+Gs4SYgM6CZQHDETBtE9HaSEkGmuNXF86RwHhHUvq4=
-github.com/klauspost/cpuid/v2 v2.0.4 h1:g0I61F2K2DjRHz1cnxlkNSBIaePVoJIjjnHui8QHbiw=
 github.com/klauspost/cpuid/v2 v2.0.4/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
+github.com/klauspost/cpuid/v2 v2.0.8 h1:bhR2mgIlno/Sfk4oUbH4sPlc83z1yGrN9bvqiq3C33I=
+github.com/klauspost/cpuid/v2 v2.0.8/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/koron/go-ssdp v0.0.0-20180514024734-4a0ed625a78b h1:wxtKgYHEncAU00muMD06dzLiahtGM1eouRNOzVV7tdQ=
 github.com/koron/go-ssdp v0.0.0-20180514024734-4a0ed625a78b/go.mod h1:5Ky9EC2xfoUKUor0Hjgi2BJhCSXJfMOFlmyYrVKGQMk=
@@ -570,8 +571,9 @@ golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
-golang.org/x/crypto v0.0.0-20210506145944-38f3c27a63bf h1:B2n+Zi5QeYRDAEodEu72OS36gmTWjgpXr2+cWcBW90o=
 golang.org/x/crypto v0.0.0-20210506145944-38f3c27a63bf/go.mod h1:P+XmwS30IXTQdn5tA2iutPOUgjI07+tq3H3K9MVA1s8=
+golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97 h1:/UOmuWzQfxxo9UtlXMwuQU8CMgg1eZXqTRwkSQJWKOI=
+golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190731235908-ec7cb31e5a56/go.mod h1:JhuoJpWY28nO4Vef9tZUw9qufEGTyX1+7lmHxV5q5G4=
 golang.org/x/exp v0.0.0-20210615023648-acb5c1269671 h1:ddvpKwqE7dm58PoWjRCmaCiA3DANEW0zWGfNYQD212Y=
@@ -648,8 +650,9 @@ golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210309074719-68d13333faf2/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57 h1:F5Gozwx4I1xtr/sr/8CFbb57iKi3297KFs0QDbGN60A=
-golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c h1:F1jZWGFhYfh0Ci55sIpILtKKK8p3i2/krTr0H1rg74I=
+golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/v2/internal/carv1/car.go
+++ b/v2/internal/carv1/car.go
@@ -11,7 +11,7 @@ import (
 	cid "github.com/ipfs/go-cid"
 	cbor "github.com/ipfs/go-ipld-cbor"
 	format "github.com/ipfs/go-ipld-format"
-	dag "github.com/ipfs/go-merkledag"
+	"github.com/ipfs/go-merkledag"
 )
 
 func init() {
@@ -49,7 +49,7 @@ func WriteCar(ctx context.Context, ds format.NodeGetter, roots []cid.Cid, w io.W
 	cw := &carWriter{ds: ds, w: w}
 	seen := cid.NewSet()
 	for _, r := range roots {
-		if err := dag.Walk(ctx, cw.enumGetLinks, r, seen.Visit); err != nil {
+		if err := merkledag.Walk(ctx, cw.enumGetLinks, r, seen.Visit); err != nil {
 			return err
 		}
 	}

--- a/v2/internal/carv1/car_test.go
+++ b/v2/internal/carv1/car_test.go
@@ -12,7 +12,7 @@ import (
 
 	cid "github.com/ipfs/go-cid"
 	format "github.com/ipfs/go-ipld-format"
-	dag "github.com/ipfs/go-merkledag"
+	"github.com/ipfs/go-merkledag"
 	dstest "github.com/ipfs/go-merkledag/test"
 )
 
@@ -26,18 +26,18 @@ func assertAddNodes(t *testing.T, ds format.DAGService, nds ...format.Node) {
 
 func TestRoundtrip(t *testing.T) {
 	dserv := dstest.Mock()
-	a := dag.NewRawNode([]byte("aaaa"))
-	b := dag.NewRawNode([]byte("bbbb"))
-	c := dag.NewRawNode([]byte("cccc"))
+	a := merkledag.NewRawNode([]byte("aaaa"))
+	b := merkledag.NewRawNode([]byte("bbbb"))
+	c := merkledag.NewRawNode([]byte("cccc"))
 
-	nd1 := &dag.ProtoNode{}
+	nd1 := &merkledag.ProtoNode{}
 	nd1.AddNodeLink("cat", a)
 
-	nd2 := &dag.ProtoNode{}
+	nd2 := &merkledag.ProtoNode{}
 	nd2.AddNodeLink("first", nd1)
 	nd2.AddNodeLink("dog", b)
 
-	nd3 := &dag.ProtoNode{}
+	nd3 := &merkledag.ProtoNode{}
 	nd3.AddNodeLink("second", nd2)
 	nd3.AddNodeLink("bear", c)
 
@@ -233,8 +233,8 @@ func TestBadHeaders(t *testing.T) {
 }
 
 func TestCarHeaderMatchess(t *testing.T) {
-	oneCid := dag.NewRawNode([]byte("fish")).Cid()
-	anotherCid := dag.NewRawNode([]byte("lobster")).Cid()
+	oneCid := merkledag.NewRawNode([]byte("fish")).Cid()
+	anotherCid := merkledag.NewRawNode([]byte("lobster")).Cid()
 	tests := []struct {
 		name  string
 		one   CarHeader

--- a/v2/writer_test.go
+++ b/v2/writer_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/ipfs/go-cid"
 	format "github.com/ipfs/go-ipld-format"
-	dag "github.com/ipfs/go-merkledag"
+	"github.com/ipfs/go-merkledag"
 	dstest "github.com/ipfs/go-merkledag/test"
 	"github.com/stretchr/testify/assert"
 )
@@ -66,25 +66,25 @@ func TestNewWriter(t *testing.T) {
 
 func generateRootCid(t *testing.T, adder format.NodeAdder) []cid.Cid {
 	// TODO convert this into a utility testing lib that takes an rng and generates a random DAG with some threshold for depth/breadth.
-	this := dag.NewRawNode([]byte("fish"))
-	that := dag.NewRawNode([]byte("lobster"))
-	other := dag.NewRawNode([]byte("🌊"))
+	this := merkledag.NewRawNode([]byte("fish"))
+	that := merkledag.NewRawNode([]byte("lobster"))
+	other := merkledag.NewRawNode([]byte("🌊"))
 
-	one := &dag.ProtoNode{}
+	one := &merkledag.ProtoNode{}
 	assertAddNodeLink(t, one, this, "fishmonger")
 
-	another := &dag.ProtoNode{}
+	another := &merkledag.ProtoNode{}
 	assertAddNodeLink(t, another, one, "barreleye")
 	assertAddNodeLink(t, another, that, "🐡")
 
-	andAnother := &dag.ProtoNode{}
+	andAnother := &merkledag.ProtoNode{}
 	assertAddNodeLink(t, andAnother, another, "🍤")
 
 	assertAddNodes(t, adder, this, that, other, one, another, andAnother)
 	return []cid.Cid{andAnother.Cid()}
 }
 
-func assertAddNodeLink(t *testing.T, pn *dag.ProtoNode, fn format.Node, name string) {
+func assertAddNodeLink(t *testing.T, pn *merkledag.ProtoNode, fn format.Node, name string) {
 	assert.NoError(t, pn.AddNodeLink(name, fn))
 }
 


### PR DESCRIPTION
Add tests that assert:
 - when padding options are set the payload is as
expected
 - when finalized, blockstore calls panic
 - when resumed from mismatching padding error is as expected
 - when resumed from non-v2 file error is as expected

Remove redundant TODOs in code