### PR TITLE
Remove memory intensive writer and add warping tests

### DIFF
--- a/v2/blockstore/readonly_test.go
+++ b/v2/blockstore/readonly_test.go
@@ -2,12 +2,13 @@ package blockstore
 
 import (
 	"context"
-	blockstore "github.com/ipfs/go-ipfs-blockstore"
-	"github.com/ipfs/go-merkledag"
 	"io"
 	"os"
 	"testing"
 	"time"
+
+	blockstore "github.com/ipfs/go-ipfs-blockstore"
+	"github.com/ipfs/go-merkledag"
 
 	blocks "github.com/ipfs/go-block-format"
 

--- a/v2/index/indexsorted_test.go
+++ b/v2/index/indexsorted_test.go
@@ -1,10 +1,11 @@
 package index
 
 import (
+	"testing"
+
 	"github.com/ipfs/go-merkledag"
 	"github.com/multiformats/go-multicodec"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestSortedIndexCodec(t *testing.T) {

--- a/v2/writer.go
+++ b/v2/writer.go
@@ -1,137 +1,13 @@
 package car
 
 import (
-	"bytes"
-	"context"
 	"io"
 	"os"
 
 	internalio "github.com/ipld/go-car/v2/internal/io"
 
-	"github.com/ipfs/go-cid"
-	format "github.com/ipfs/go-ipld-format"
 	"github.com/ipld/go-car/v2/index"
-	"github.com/ipld/go-car/v2/internal/carv1"
 )
-
-const bulkPaddingBytesSize = 1024
-
-var bulkPadding = make([]byte, bulkPaddingBytesSize)
-
-type (
-	// padding represents the number of padding bytes.
-	padding uint64
-	// writer writes CAR v2 into a given io.Writer.
-	writer struct {
-		NodeGetter   format.NodeGetter
-		CarV1Padding uint64
-		IndexPadding uint64
-
-		ctx          context.Context
-		roots        []cid.Cid
-		encodedCarV1 *bytes.Buffer
-	}
-)
-
-// WriteTo writes this padding to the given writer as default value bytes.
-func (p padding) WriteTo(w io.Writer) (n int64, err error) {
-	var reminder int64
-	if p > bulkPaddingBytesSize {
-		reminder = int64(p % bulkPaddingBytesSize)
-		iter := int(p / bulkPaddingBytesSize)
-		for i := 0; i < iter; i++ {
-			if _, err = w.Write(bulkPadding); err != nil {
-				return
-			}
-			n += bulkPaddingBytesSize
-		}
-	} else {
-		reminder = int64(p)
-	}
-
-	paddingBytes := make([]byte, reminder)
-	_, err = w.Write(paddingBytes)
-	n += reminder
-	return
-}
-
-// newWriter instantiates a new CAR v2 writer.
-func newWriter(ctx context.Context, ng format.NodeGetter, roots []cid.Cid) *writer {
-	return &writer{
-		NodeGetter:   ng,
-		ctx:          ctx,
-		roots:        roots,
-		encodedCarV1: new(bytes.Buffer),
-	}
-}
-
-// WriteTo writes the given root CIDs according to CAR v2 specification.
-func (w *writer) WriteTo(writer io.Writer) (n int64, err error) {
-	_, err = writer.Write(Pragma)
-	if err != nil {
-		return
-	}
-	n += int64(PragmaSize)
-	// We read the entire car into memory because GenerateIndex takes a reader.
-	// TODO Future PRs will make this more efficient by exposing necessary interfaces in index pacakge so that
-	// this can be done in an streaming manner.
-	if err = carv1.WriteCar(w.ctx, w.NodeGetter, w.roots, w.encodedCarV1); err != nil {
-		return
-	}
-	carV1Len := w.encodedCarV1.Len()
-
-	wn, err := w.writeHeader(writer, carV1Len)
-	if err != nil {
-		return
-	}
-	n += wn
-
-	wn, err = padding(w.CarV1Padding).WriteTo(writer)
-	if err != nil {
-		return
-	}
-	n += wn
-
-	carV1Bytes := w.encodedCarV1.Bytes()
-	wwn, err := writer.Write(carV1Bytes)
-	if err != nil {
-		return
-	}
-	n += int64(wwn)
-
-	wn, err = padding(w.IndexPadding).WriteTo(writer)
-	if err != nil {
-		return
-	}
-	n += wn
-
-	wn, err = w.writeIndex(writer, carV1Bytes)
-	if err == nil {
-		n += wn
-	}
-	return
-}
-
-func (w *writer) writeHeader(writer io.Writer, carV1Len int) (int64, error) {
-	header := NewHeader(uint64(carV1Len)).
-		WithCarV1Padding(w.CarV1Padding).
-		WithIndexPadding(w.IndexPadding)
-	return header.WriteTo(writer)
-}
-
-func (w *writer) writeIndex(writer io.Writer, carV1 []byte) (int64, error) {
-	// TODO avoid recopying the bytes by refactoring index once it is integrated here.
-	// Right now we copy the bytes since index takes a writer.
-	// Consider refactoring index to make this process more efficient.
-	// We should avoid reading the entire car into memory since it can be large.
-	reader := bytes.NewReader(carV1)
-	idx, err := GenerateIndex(reader)
-	if err != nil {
-		return 0, err
-	}
-	// FIXME refactor index to expose the number of bytes written.
-	return 0, index.WriteTo(idx, writer)
-}
 
 // WrapV1File is a wrapper around WrapV1 that takes filesystem paths.
 // The source path is assumed to exist, and the destination path is overwritten.


### PR DESCRIPTION
Remove the memory intensive CARv2 writer implementation since it needs
to be reimplemented anyway and not used. We will release writers if
needed when it comes to SelectiveCar writer implementation. Just now it
is not clear if we want a CARv2 writer that works with the deprecated
`format.NodeGetter`.

Add tests for V1 wrapping functionality.

Reformat code in repo for consistency using `gofumpt`.