### PR TITLE
Rename `CarV1` with `Data` in API to be consistent with spec

### DIFF
--- a/v2/blockstore/doc.go
+++ b/v2/blockstore/doc.go
@@ -2,11 +2,11 @@
 // This package provides two flavours of blockstore: ReadOnly and ReadWrite.
 //
 // The ReadOnly blockstore provides a read-only random access from a given data payload either in
-// unindexed v1 format or indexed/unindexed v2 format:
-// * ReadOnly.NewReadOnly can be used to instantiate a new read-only blockstore for a given CAR v1
-//   or CAR v2 data payload with an optional index override.
-// * ReadOnly.OpenReadOnly can be used to instantiate a new read-only blockstore for a given CAR v1
-//    or CAR v2 file with automatic index generation if the index is not present.
+// unindexed CARv1 format or indexed/unindexed v2 format:
+// * ReadOnly.NewReadOnly can be used to instantiate a new read-only blockstore for a given CARv1
+//   or CARv2 data payload with an optional index override.
+// * ReadOnly.OpenReadOnly can be used to instantiate a new read-only blockstore for a given CARv1
+//    or CARv2 file with automatic index generation if the index is not present.
 //
 // The ReadWrite blockstore allows writing and reading of the blocks concurrently. The user of this
 // blockstore is responsible for calling ReadWrite.Finalize when finished writing blocks.

--- a/v2/blockstore/readonly_test.go
+++ b/v2/blockstore/readonly_test.go
@@ -131,7 +131,7 @@ func newReaderFromV2File(t *testing.T, carv2Path string) *carv1.CarReader {
 	t.Cleanup(func() { f.Close() })
 	v2r, err := carv2.NewReader(f)
 	require.NoError(t, err)
-	v1r, err := carv1.NewCarReader(v2r.CarV1Reader())
+	v1r, err := carv1.NewCarReader(v2r.DataReader())
 	require.NoError(t, err)
 	return v1r
 }

--- a/v2/car.go
+++ b/v2/car.go
@@ -33,7 +33,7 @@ type (
 		DataOffset uint64
 		// The byte-length of the CARv1 data payload.
 		DataSize uint64
-		// Te byte-offset from the beginning of the CARv2 to the first byte of the index payload. This value may be 0 to indicate the absence of index data.
+		// The byte-offset from the beginning of the CARv2 to the first byte of the index payload. This value may be 0 to indicate the absence of index data.
 		IndexOffset uint64
 	}
 	// Characteristics is a bitfield placeholder for capturing the characteristics of a CARv2 such as order and determinism.

--- a/v2/car.go
+++ b/v2/car.go
@@ -6,16 +6,16 @@ import (
 )
 
 const (
-	// PragmaSize is the size of the CAR v2 pragma in bytes.
+	// PragmaSize is the size of the CARv2 pragma in bytes.
 	PragmaSize = 11
-	// HeaderSize is the fixed size of CAR v2 header in number of bytes.
+	// HeaderSize is the fixed size of CARv2 header in number of bytes.
 	HeaderSize = 40
-	// CharacteristicsSize is the fixed size of Characteristics bitfield within CAR v2 header in number of bytes.
+	// CharacteristicsSize is the fixed size of Characteristics bitfield within CARv2 header in number of bytes.
 	CharacteristicsSize = 16
 )
 
-// The pragma of a CAR v2, containing the version number..
-// This is a valid CAR v1 header, with version number set to 2.
+// The pragma of a CARv2, containing the version number.
+// This is a valid CARv1 header, with version number of 2 and no root CIDs.
 var Pragma = []byte{
 	0x0a,                                     // unit(10)
 	0xa1,                                     // map(1)
@@ -25,18 +25,18 @@ var Pragma = []byte{
 }
 
 type (
-	// Header represents the CAR v2 header/pragma.
+	// Header represents the CARv2 header/pragma.
 	Header struct {
-		// 128-bit characteristics of this CAR v2 file, such as order, deduplication, etc. Reserved for future use.
+		// 128-bit characteristics of this CARv2 file, such as order, deduplication, etc. Reserved for future use.
 		Characteristics Characteristics
-		// The offset from the beginning of the file at which the dump of CAR v1 starts.
-		CarV1Offset uint64
-		// The size of CAR v1 encapsulated in this CAR v2 as bytes.
-		CarV1Size uint64
-		// The offset from the beginning of the file at which the CAR v2 index begins.
+		// The byte-offset from the beginning of the CARv2 to the first byte of the CARv1 data payload.
+		DataOffset uint64
+		// The byte-length of the CARv1 data payload.
+		DataSize uint64
+		// Te byte-offset from the beginning of the CARv2 to the first byte of the index payload. This value may be 0 to indicate the absence of index data.
 		IndexOffset uint64
 	}
-	// Characteristics is a bitfield placeholder for capturing the characteristics of a CAR v2 such as order and determinism.
+	// Characteristics is a bitfield placeholder for capturing the characteristics of a CARv2 such as order and determinism.
 	Characteristics struct {
 		Hi uint64
 		Lo uint64
@@ -64,37 +64,37 @@ func (c *Characteristics) ReadFrom(r io.Reader) (int64, error) {
 	return n, nil
 }
 
-// NewHeader instantiates a new CAR v2 header, given the byte length of a CAR v1.
-func NewHeader(carV1Size uint64) Header {
+// NewHeader instantiates a new CARv2 header, given the data size.
+func NewHeader(dataSize uint64) Header {
 	header := Header{
-		CarV1Size: carV1Size,
+		DataSize: dataSize,
 	}
-	header.CarV1Offset = PragmaSize + HeaderSize
-	header.IndexOffset = header.CarV1Offset + carV1Size
+	header.DataOffset = PragmaSize + HeaderSize
+	header.IndexOffset = header.DataOffset + dataSize
 	return header
 }
 
-// WithIndexPadding sets the index offset from the beginning of the file for this header and returns the
-// header for convenient chained calls.
+// WithIndexPadding sets the index offset from the beginning of the file for this header and returns
+// the header for convenient chained calls.
 // The index offset is calculated as the sum of PragmaSize, HeaderSize,
-// Header.CarV1Size, and the given padding.
+// Header.DataSize, and the given padding.
 func (h Header) WithIndexPadding(padding uint64) Header {
 	h.IndexOffset = h.IndexOffset + padding
 	return h
 }
 
-// WithCarV1Padding sets the CAR v1 dump offset from the beginning of the file for this header and returns the
-// header for convenient chained calls.
-// The CAR v1 offset is calculated as the sum of PragmaSize, HeaderSize and the given padding.
+// WithDataPadding sets the data payload byte-offset from the beginning of the file for this header
+// and returns the header for convenient chained calls.
+// The Data offset is calculated as the sum of PragmaSize, HeaderSize and the given padding.
 // The call to this function also shifts the Header.IndexOffset forward by the given padding.
-func (h Header) WithCarV1Padding(padding uint64) Header {
-	h.CarV1Offset = PragmaSize + HeaderSize + padding
+func (h Header) WithDataPadding(padding uint64) Header {
+	h.DataOffset = PragmaSize + HeaderSize + padding
 	h.IndexOffset = h.IndexOffset + padding
 	return h
 }
 
-func (h Header) WithCarV1Size(size uint64) Header {
-	h.CarV1Size = size
+func (h Header) WithDataSize(size uint64) Header {
+	h.DataSize = size
 	h.IndexOffset = size + h.IndexOffset
 	return h
 }
@@ -112,8 +112,8 @@ func (h Header) WriteTo(w io.Writer) (n int64, err error) {
 		return
 	}
 	buf := make([]byte, 24)
-	binary.LittleEndian.PutUint64(buf[:8], h.CarV1Offset)
-	binary.LittleEndian.PutUint64(buf[8:16], h.CarV1Size)
+	binary.LittleEndian.PutUint64(buf[:8], h.DataOffset)
+	binary.LittleEndian.PutUint64(buf[8:16], h.DataSize)
 	binary.LittleEndian.PutUint64(buf[16:], h.IndexOffset)
 	written, err := w.Write(buf)
 	n += int64(written)
@@ -132,8 +132,8 @@ func (h *Header) ReadFrom(r io.Reader) (int64, error) {
 	if err != nil {
 		return n, err
 	}
-	h.CarV1Offset = binary.LittleEndian.Uint64(buf[:8])
-	h.CarV1Size = binary.LittleEndian.Uint64(buf[8:16])
+	h.DataOffset = binary.LittleEndian.Uint64(buf[:8])
+	h.DataSize = binary.LittleEndian.Uint64(buf[8:16])
 	h.IndexOffset = binary.LittleEndian.Uint64(buf[16:])
 	return n, nil
 }

--- a/v2/car_test.go
+++ b/v2/car_test.go
@@ -36,11 +36,11 @@ func TestCarV2PragmaLength(t *testing.T) {
 
 func TestCarV2PragmaIsValidCarV1Header(t *testing.T) {
 	v1h, err := carv1.ReadHeader(bytes.NewReader(carv2.Pragma))
-	assert.NoError(t, err, "cannot decode pragma as CBOR with CAR v1 header structure")
+	assert.NoError(t, err, "cannot decode pragma as CBOR with CARv1 header structure")
 	assert.Equal(t, &carv1.CarHeader{
 		Roots:   nil,
 		Version: 2,
-	}, v1h, "CAR v2 pragma must be a valid CAR v1 header")
+	}, v1h, "CARv2 pragma must be a valid CARv1 header")
 }
 
 func TestHeader_WriteTo(t *testing.T) {
@@ -70,8 +70,8 @@ func TestHeader_WriteTo(t *testing.T) {
 				Characteristics: carv2.Characteristics{
 					Hi: 1001, Lo: 1002,
 				},
-				CarV1Offset: 99,
-				CarV1Size:   100,
+				DataOffset:  99,
+				DataSize:    100,
 				IndexOffset: 101,
 			},
 			[]byte{
@@ -94,8 +94,8 @@ func TestHeader_WriteTo(t *testing.T) {
 			}
 			gotWrite := buf.Bytes()
 			assert.Equal(t, tt.wantWrite, gotWrite, "Header.WriteTo() gotWrite = %v, wantWrite %v", gotWrite, tt.wantWrite)
-			assert.EqualValues(t, carv2.HeaderSize, uint64(len(gotWrite)), "WriteTo() CAR v2 header length must always be %v bytes long", carv2.HeaderSize)
-			assert.EqualValues(t, carv2.HeaderSize, uint64(written), "WriteTo() CAR v2 header byte count must always be %v bytes long", carv2.HeaderSize)
+			assert.EqualValues(t, carv2.HeaderSize, uint64(len(gotWrite)), "WriteTo() CARv2 header length must always be %v bytes long", carv2.HeaderSize)
+			assert.EqualValues(t, carv2.HeaderSize, uint64(written), "WriteTo() CARv2 header byte count must always be %v bytes long", carv2.HeaderSize)
 		})
 	}
 }
@@ -135,8 +135,8 @@ func TestHeader_ReadFrom(t *testing.T) {
 				Characteristics: carv2.Characteristics{
 					Hi: 1001, Lo: 1002,
 				},
-				CarV1Offset: 99,
-				CarV1Size:   100,
+				DataOffset:  99,
+				DataSize:    100,
 				IndexOffset: 101,
 			},
 			false,
@@ -168,13 +168,13 @@ func TestHeader_WithPadding(t *testing.T) {
 		},
 		{
 			"WhenOnlyPaddingCarV1BothOffsetsShift",
-			carv2.NewHeader(123).WithCarV1Padding(3),
+			carv2.NewHeader(123).WithDataPadding(3),
 			carv2.PragmaSize + carv2.HeaderSize + 3,
 			carv2.PragmaSize + carv2.HeaderSize + 3 + 123,
 		},
 		{
 			"WhenPaddingBothCarV1AndIndexBothOffsetsShiftWithAdditionalIndexShift",
-			carv2.NewHeader(123).WithCarV1Padding(3).WithIndexPadding(7),
+			carv2.NewHeader(123).WithDataPadding(3).WithIndexPadding(7),
 			carv2.PragmaSize + carv2.HeaderSize + 3,
 			carv2.PragmaSize + carv2.HeaderSize + 3 + 123 + 7,
 		},
@@ -182,7 +182,7 @@ func TestHeader_WithPadding(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.EqualValues(t, tt.wantCarV1Offset, tt.subject.CarV1Offset)
+			assert.EqualValues(t, tt.wantCarV1Offset, tt.subject.DataOffset)
 			assert.EqualValues(t, tt.wantIndexOffset, tt.subject.IndexOffset)
 		})
 	}
@@ -192,8 +192,8 @@ func TestNewHeaderHasExpectedValues(t *testing.T) {
 	wantCarV1Len := uint64(1413)
 	want := carv2.Header{
 		Characteristics: carv2.Characteristics{},
-		CarV1Offset:     carv2.PragmaSize + carv2.HeaderSize,
-		CarV1Size:       wantCarV1Len,
+		DataOffset:      carv2.PragmaSize + carv2.HeaderSize,
+		DataSize:        wantCarV1Len,
 		IndexOffset:     carv2.PragmaSize + carv2.HeaderSize + wantCarV1Len,
 	}
 	got := carv2.NewHeader(wantCarV1Len)

--- a/v2/doc.go
+++ b/v2/doc.go
@@ -1,3 +1,3 @@
-// Package car represents the CAR v2 implementation.
-// TODO add CAR v2 byte structure here.
+// Package car represents the CARv2 implementation.
+// TODO add CARv2 byte structure here.
 package car

--- a/v2/example_test.go
+++ b/v2/example_test.go
@@ -38,7 +38,7 @@ func ExampleWrapV1File() {
 	if err != nil {
 		panic(err)
 	}
-	inner, err := ioutil.ReadAll(cr.CarV1Reader())
+	inner, err := ioutil.ReadAll(cr.DataReader())
 	if err != nil {
 		panic(err)
 	}

--- a/v2/index/doc.go
+++ b/v2/index/doc.go
@@ -1,5 +1,5 @@
-// package index provides indexing functionality for CAR v1 data payload represented as a mapping of
-// CID to offset. This can then be used to implement random access over a CAR v1.
+// package index provides indexing functionality for CARv1 data payload represented as a mapping of
+// CID to offset. This can then be used to implement random access over a CARv1.
 //
 // Index can be written or read using the following static functions: index.WriteTo and
 // index.ReadFrom.

--- a/v2/index_gen.go
+++ b/v2/index_gen.go
@@ -63,10 +63,10 @@ func GenerateIndex(v1r io.Reader, opts ...ReadOption) (index.Index, error) {
 
 		// Null padding; by default it's an error.
 		if sectionLen == 0 {
-			if o.ZeroLegthSectionAsEOF {
+			if o.ZeroLengthSectionAsEOF {
 				break
 			} else {
-				return nil, fmt.Errorf("carv1 null padding not allowed by default; see ZeroLegthSectionAsEOF")
+				return nil, fmt.Errorf("carv1 null padding not allowed by default; see ZeroLengthSectionAsEOF")
 			}
 		}
 
@@ -103,10 +103,10 @@ func GenerateIndexFromFile(path string) (index.Index, error) {
 	return GenerateIndex(f)
 }
 
-// ReadOrGenerateIndex accepts both CAR v1 and v2 format, and reads or generates an index for it.
-// When the given reader is in CAR v1 format an index is always generated.
-// For a payload in CAR v2 format, an index is only generated if Header.HasIndex returns false.
-// An error is returned for all other formats, i.e. versions other than 1 or 2.
+// ReadOrGenerateIndex accepts both CARv1 and CARv2 formats, and reads or generates an index for it.
+// When the given reader is in CARv1 format an index is always generated.
+// For a payload in CARv2 format, an index is only generated if Header.HasIndex returns false.
+// An error is returned for all other formats, i.e. pragma with versions other than 1 or 2.
 //
 // Note, the returned index lives entirely in memory and will not depend on the
 // given reader to fulfill index lookup.
@@ -126,7 +126,7 @@ func ReadOrGenerateIndex(rs io.ReadSeeker) (index.Index, error) {
 		// Simply generate the index, since there can't be a pre-existing one.
 		return GenerateIndex(rs)
 	case 2:
-		// Read CAR v2 format
+		// Read CARv2 format
 		v2r, err := NewReader(internalio.ToReaderAt(rs))
 		if err != nil {
 			return nil, err
@@ -135,8 +135,8 @@ func ReadOrGenerateIndex(rs io.ReadSeeker) (index.Index, error) {
 		if v2r.Header.HasIndex() {
 			return index.ReadFrom(v2r.IndexReader())
 		}
-		// Otherwise, generate index from CAR v1 payload wrapped within CAR v2 format.
-		return GenerateIndex(v2r.CarV1Reader())
+		// Otherwise, generate index from CARv1 payload wrapped within CARv2 format.
+		return GenerateIndex(v2r.DataReader())
 	default:
 		return nil, fmt.Errorf("unknown version %v", version)
 	}

--- a/v2/internal/carv1/doc.go
+++ b/v2/internal/carv1/doc.go
@@ -1,2 +1,2 @@
-// Forked from CAR v1 to avoid dependency to ipld-prime 0.9.0 due to outstanding upgrades in filecoin.
+// Forked from CARv1 to avoid dependency to ipld-prime 0.9.0 due to outstanding upgrades in filecoin.
 package carv1

--- a/v2/options.go
+++ b/v2/options.go
@@ -6,7 +6,7 @@ package car
 // This type should not be used directly by end users; it's only exposed as a
 // side effect of ReadOption.
 type ReadOptions struct {
-	ZeroLegthSectionAsEOF bool
+	ZeroLengthSectionAsEOF bool
 
 	BlockstoreUseWholeCIDs bool
 }
@@ -24,7 +24,7 @@ var _ ReadWriteOption = ReadOption(nil)
 // This type should not be used directly by end users; it's only exposed as a
 // side effect of WriteOption.
 type WriteOptions struct {
-	CarV1Padding uint64
+	DataPadding  uint64
 	IndexPadding uint64
 
 	BlockstoreAllowDuplicatePuts bool
@@ -42,19 +42,19 @@ type ReadWriteOption interface {
 	readWriteOption()
 }
 
-// ZeroLegthSectionAsEOF is a read option which allows a CARv1 decoder to treat
+// ZeroLengthSectionAsEOF is a read option which allows a CARv1 decoder to treat
 // a zero-length section as the end of the input CAR file. For example, this can
 // be useful to allow "null padding" after a CARv1 without knowing where the
 // padding begins.
-func ZeroLegthSectionAsEOF(o *ReadOptions) {
-	o.ZeroLegthSectionAsEOF = true
+func ZeroLengthSectionAsEOF(o *ReadOptions) {
+	o.ZeroLengthSectionAsEOF = true
 }
 
-// UseCarV1Padding is a write option which sets the padding to be added between
-// CAR v2 header and its data payload on Finalize.
-func UseCarV1Padding(p uint64) WriteOption {
+// UseDataPadding is a write option which sets the padding to be added between
+// CARv2 header and its data payload on Finalize.
+func UseDataPadding(p uint64) WriteOption {
 	return func(o *WriteOptions) {
-		o.CarV1Padding = p
+		o.DataPadding = p
 	}
 }
 

--- a/v2/writer.go
+++ b/v2/writer.go
@@ -79,11 +79,11 @@ func WrapV1(src io.ReadSeeker, dst io.Writer) error {
 	return nil
 }
 
-// AttachIndex attaches a given index to an existing car v2 file at given path and offset.
+// AttachIndex attaches a given index to an existing CARv2 file at given path and offset.
 func AttachIndex(path string, idx index.Index, offset uint64) error {
 	// TODO: instead of offset, maybe take padding?
-	// TODO: check that the given path is indeed a CAR v2.
-	// TODO: update CAR v2 header according to the offset at which index is written out.
+	// TODO: check that the given path is indeed a CARv2.
+	// TODO: update CARv2 header according to the offset at which index is written out.
 	out, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o640)
 	if err != nil {
 		return err

--- a/v2/writer_test.go
+++ b/v2/writer_test.go
@@ -47,7 +47,7 @@ func TestWrapV1(t *testing.T) {
 	require.NoError(t, err)
 	wantPayload, err := ioutil.ReadAll(sf)
 	require.NoError(t, err)
-	gotPayload, err := ioutil.ReadAll(subject.CarV1Reader())
+	gotPayload, err := ioutil.ReadAll(subject.DataReader())
 	require.NoError(t, err)
 	require.Equal(t, wantPayload, gotPayload)
 


### PR DESCRIPTION
Rename terminology to match what the spec uses to describe the inner
CARv1 payload, i.e. Data payload.

Update docs to use CARv1 and CARv2 consistently.

Fix typo in Options API.

See:
- https://ipld.io/specs/transport/car/carv2/