### PR TITLE
Avoid writing to files in `testdata`

### DIFF
--- a/v2/blockstore/example_test.go
+++ b/v2/blockstore/example_test.go
@@ -3,6 +3,9 @@ package blockstore_test
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
 
 	blocks "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-cid"
@@ -76,10 +79,14 @@ func ExampleOpenReadWrite() {
 	thatBlock := merkledag.NewRawNode([]byte("lobster")).Block
 	andTheOtherBlock := merkledag.NewRawNode([]byte("barreleye")).Block
 
-	dest := "../testdata/sample-rw-bs-v2.car"
+	tdir, err := ioutil.TempDir(os.TempDir(), "example-*")
+	if err != nil {
+		panic(err)
+	}
+	dst := filepath.Join(tdir, "sample-rw-bs-v2.car")
 	roots := []cid.Cid{thisBlock.Cid(), thatBlock.Cid(), andTheOtherBlock.Cid()}
 
-	rwbs, err := blockstore.OpenReadWrite(dest, roots, carv2.UseDataPadding(1413), carv2.UseIndexPadding(42))
+	rwbs, err := blockstore.OpenReadWrite(dst, roots, carv2.UseDataPadding(1413), carv2.UseIndexPadding(42))
 	if err != nil {
 		panic(err)
 	}
@@ -107,7 +114,7 @@ func ExampleOpenReadWrite() {
 	// Resume from the same file to add more blocks.
 	// Note the UseDataPadding and roots must match the values passed to the blockstore instance
 	// that created the original file. Otherwise, we cannot resume from the same file.
-	resumedRwbos, err := blockstore.OpenReadWrite(dest, roots, carv2.UseDataPadding(1413))
+	resumedRwbos, err := blockstore.OpenReadWrite(dst, roots, carv2.UseDataPadding(1413))
 	if err != nil {
 		panic(err)
 	}

--- a/v2/blockstore/readwrite_test.go
+++ b/v2/blockstore/readwrite_test.go
@@ -535,9 +535,27 @@ func TestReadWriteWithPaddingWorksAsExpected(t *testing.T) {
 }
 
 func TestReadWriteResumptionFromNonV2FileIsError(t *testing.T) {
-	subject, err := blockstore.OpenReadWrite("../testdata/sample-rootless-v42.car", []cid.Cid{})
+	tmpPath := requireTmpCopy(t, "../testdata/sample-rootless-v42.car")
+	subject, err := blockstore.OpenReadWrite(tmpPath, []cid.Cid{})
 	require.EqualError(t, err, "cannot resume on CAR file with version 42")
 	require.Nil(t, subject)
+}
+
+func requireTmpCopy(t *testing.T, src string) string {
+	srcF, err := os.Open(src)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, srcF.Close()) })
+	stats, err := srcF.Stat()
+	require.NoError(t, err)
+
+	dst := filepath.Join(t.TempDir(), stats.Name())
+	dstF, err := os.Create(dst)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, dstF.Close()) })
+
+	_, err = io.Copy(dstF, srcF)
+	require.NoError(t, err)
+	return dst
 }
 
 func TestReadWriteResumptionFromFileWithDifferentCarV1PaddingIsError(t *testing.T) {

--- a/v2/example_test.go
+++ b/v2/example_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
+	"os"
+	"path/filepath"
 
 	carv2 "github.com/ipld/go-car/v2"
 	"github.com/ipld/go-car/v2/blockstore"
@@ -15,7 +17,11 @@ func ExampleWrapV1File() {
 	// Writing the result to testdata allows reusing that file in other tests,
 	// and also helps ensure that the result is deterministic.
 	src := "testdata/sample-v1.car"
-	dst := "testdata/sample-wrapped-v2.car"
+	tdir, err := ioutil.TempDir(os.TempDir(), "example-*")
+	if err != nil {
+		panic(err)
+	}
+	dst := filepath.Join(tdir, "wrapped-v2.car")
 	if err := carv2.WrapV1File(src, dst); err != nil {
 		panic(err)
 	}

--- a/v2/index/example_test.go
+++ b/v2/index/example_test.go
@@ -3,7 +3,9 @@ package index_test
 import (
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
+	"path/filepath"
 	"reflect"
 
 	carv2 "github.com/ipld/go-car/v2"
@@ -67,8 +69,12 @@ func ExampleWriteTo() {
 	}
 
 	// Store the index alone onto destination file.
-	dest := "../testdata/sample-index.carindex"
-	f, err := os.Create(dest)
+	tdir, err := ioutil.TempDir(os.TempDir(), "example-*")
+	if err != nil {
+		panic(err)
+	}
+	dst := filepath.Join(tdir, "index.carindex")
+	f, err := os.Create(dst)
 	if err != nil {
 		panic(err)
 	}
@@ -96,11 +102,11 @@ func ExampleWriteTo() {
 
 	// Expect indices to be equal.
 	if reflect.DeepEqual(idx, reReadIdx) {
-		fmt.Printf("Saved index file at %v matches the index embedded in CARv2 at %v.\n", dest, src)
+		fmt.Printf("Saved index file matches the index embedded in CARv2 at %v.\n", src)
 	} else {
 		panic("expected to get the same index as the CARv2 file")
 	}
 
 	// Output:
-	// Saved index file at ../testdata/sample-index.carindex matches the index embedded in CARv2 at ../testdata/sample-wrapped-v2.car.
+	// Saved index file matches the index embedded in CARv2 at ../testdata/sample-wrapped-v2.car.
 }

--- a/v2/index/example_test.go
+++ b/v2/index/example_test.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"path/filepath"
 	"reflect"
 
 	carv2 "github.com/ipld/go-car/v2"
@@ -69,12 +68,7 @@ func ExampleWriteTo() {
 	}
 
 	// Store the index alone onto destination file.
-	tdir, err := ioutil.TempDir(os.TempDir(), "example-*")
-	if err != nil {
-		panic(err)
-	}
-	dst := filepath.Join(tdir, "index.carindex")
-	f, err := os.Create(dst)
+	f, err := ioutil.TempFile(os.TempDir(), "example-index-*.carindex")
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Avoid writing to files in `testdata` through examples. This is because
when tests that use those file are run in parallel will fail if files
are modified. Instead write to a temporary file in examples, and
whenever opening testdata files in `RW` mode, make a temporary copy.

Thanks to @mvdan for pointing this out.

Fixes #175