### PR TITLE
Add zero-length sections as EOF option to internal CARv1 reader

### DIFF
--- a/v2/blockstore/readonly.go
+++ b/v2/blockstore/readonly.go
@@ -162,7 +162,7 @@ func OpenReadOnly(path string, opts ...carv2.ReadOption) (*ReadOnly, error) {
 }
 
 func (b *ReadOnly) readBlock(idx int64) (cid.Cid, []byte, error) {
-	bcid, data, err := util.ReadNode(internalio.NewOffsetReadSeeker(b.backing, idx))
+	bcid, data, err := util.ReadNode(internalio.NewOffsetReadSeeker(b.backing, idx), b.ropts.ZeroLengthSectionAsEOF)
 	return bcid, data, err
 }
 
@@ -252,7 +252,7 @@ func (b *ReadOnly) GetSize(key cid.Cid) (int, error) {
 	b.mu.RLock()
 	defer b.mu.RUnlock()
 
-	var fnSize int = -1
+	fnSize := -1
 	var fnErr error
 	err := b.idx.GetAll(key, func(offset uint64) bool {
 		rdr := internalio.NewOffsetReadSeeker(b.backing, int64(offset))

--- a/v2/index/index_test.go
+++ b/v2/index/index_test.go
@@ -77,7 +77,7 @@ func TestReadFrom(t *testing.T) {
 		require.NoError(t, err)
 
 		// Read the fame at offset and assert the frame corresponds to the expected block.
-		gotCid, gotData, err := util.ReadNode(crf)
+		gotCid, gotData, err := util.ReadNode(crf, false)
 		require.NoError(t, err)
 		gotBlock, err := blocks.NewBlockWithCid(gotData, gotCid)
 		require.NoError(t, err)


### PR DESCRIPTION
The CARv2 implementation uses an internal fork of CARv1 due to upstream
dependency issues captured in #104. Propagate the options set in CARv2
APIs for treatment of zero-lenth sections onto internal packages so that
APIs using the internal CARv1 reader behave consistently. Use a `bool`
for setting the option, since it is the only option needed in CARv1.

Update tests to reflect changes.

Add additional tests to internal CARv1 package and ReadOnly blockstore
that assert option is propagated.

Fixes #190
