### PR TITLE
stop allocating on every byte read (for CIDs and varints)

### DIFF
--- a/v2/internal/io/converter.go
+++ b/v2/internal/io/converter.go
@@ -63,11 +63,11 @@ func ToReaderAt(rs io.ReadSeeker) io.ReaderAt {
 	return &readSeekerAt{rs: rs}
 }
 
-func (rb readerPlusByte) ReadByte() (byte, error) {
+func (rb *readerPlusByte) ReadByte() (byte, error) {
 	return readByte(rb)
 }
 
-func (rsb readSeekerPlusByte) ReadByte() (byte, error) {
+func (rsb *readSeekerPlusByte) ReadByte() (byte, error) {
 	return readByte(rsb)
 }
 


### PR DESCRIPTION
(see commit messages - please do not squash)

Using ReadBlocks as an example, we have 30% fewer allocs and 7% less cpu usage.

https://github.com/ipfs/go-cid/pull/132 does another 11% and 3%, respectively.