### PR TITLE
Fix index GetAll infinite loop if function always returns `true`

### DIFF
--- a/v2/index/indexsorted.go
+++ b/v2/index/indexsorted.go
@@ -85,15 +85,21 @@ func (s *singleWidthIndex) getAll(d []byte, fn func(uint64) bool) error {
 	idx := sort.Search(int(s.len), func(i int) bool {
 		return s.Less(i, d)
 	})
-	if uint64(idx) == s.len {
-		return ErrNotFound
-	}
 
-	any := false
-	for bytes.Equal(d[:], s.index[idx*int(s.width):(idx+1)*int(s.width)-8]) {
-		any = true
-		offset := binary.LittleEndian.Uint64(s.index[(idx+1)*int(s.width)-8 : (idx+1)*int(s.width)])
-		if !fn(offset) {
+	var any bool
+	for ; uint64(idx) < s.len; idx++ {
+		digestStart := idx * int(s.width)
+		offsetEnd := (idx + 1) * int(s.width)
+		digestEnd := offsetEnd - 8
+		if bytes.Equal(d[:], s.index[digestStart:digestEnd]) {
+			any = true
+			offset := binary.LittleEndian.Uint64(s.index[digestEnd:offsetEnd])
+			if !fn(offset) {
+				// User signalled to stop searching; therefore, break.
+				break
+			}
+		} else {
+			// No more matches; therefore, break.
 			break
 		}
 	}

--- a/v2/index/indexsorted_test.go
+++ b/v2/index/indexsorted_test.go
@@ -1,6 +1,7 @@
 package index
 
 import (
+	"encoding/binary"
 	"testing"
 
 	"github.com/ipfs/go-merkledag"
@@ -30,4 +31,34 @@ func TestSortedIndex_GetReturnsNotFoundWhenCidDoesNotExist(t *testing.T) {
 			require.Equal(t, uint64(0), gotOffset)
 		})
 	}
+}
+
+func TestSingleWidthIndex_GetAll(t *testing.T) {
+	l := 4
+	width := 9
+	buf := make([]byte, width*l)
+
+	// Populate the index bytes as total of four records.
+	// The last record should not match the getAll.
+	for i := 0; i < l; i++ {
+		if i < l-1 {
+			buf[i*width] = 1
+		} else {
+			buf[i*width] = 2
+		}
+		binary.LittleEndian.PutUint64(buf[(i*width)+1:(i*width)+width], uint64(14))
+	}
+	subject := &singleWidthIndex{
+		width: 9,
+		len:   uint64(l),
+		index: buf,
+	}
+
+	var foundCount int
+	err := subject.getAll([]byte{1}, func(u uint64) bool {
+		foundCount++
+		return true
+	})
+	require.NoError(t, err)
+	require.Equal(t, 3, foundCount)
 }


### PR DESCRIPTION
Refine `GetAll` logic so that it stops iteration if either function
returns false or there are no more entries to search.

Fixes #216