### PR TITLE
use file size when loading from v1 car

### DIFF
--- a/v2/cmd/car/index.go
+++ b/v2/cmd/car/index.go
@@ -46,6 +46,13 @@ func IndexCar(c *cli.Context) error {
 
 	v1r := r.DataReader()
 
+	if r.Version == 1 {
+		fi, err := os.Stat(c.Args().Get(0))
+		if err != nil {
+			return err
+		}
+		r.Header.DataSize = uint64(fi.Size())
+	}
 	v2Header := carv2.NewHeader(r.Header.DataSize)
 	if c.String("codec") == "none" {
 		v2Header.IndexOffset = 0


### PR DESCRIPTION
When running `car index` from a v1 file, the wrong data length was being used for the wrapped v2 header.