### PR TITLE
Implement options to handle `IDENTITY` CIDs gracefully

### DIFF
--- a/v2/blockstore/doc.go
+++ b/v2/blockstore/doc.go
@@ -22,7 +22,7 @@
 // * blockstore.Has will always return true.
 // * blockstore.Get will always succeed, returning the multihash digest of the given CID.
 // * blockstore.GetSize will always succeed, returning the multihash digest length of the given CID.
-// * blockstore.Put and blockstore.PutMany will always succeed without performing any operation.
+// * blockstore.Put and blockstore.PutMany will always succeed without performing any operation unless car.StoreIdentityCIDs is enabled.
 //
 // See: https://pkg.go.dev/github.com/ipfs/go-ipfs-blockstore#NewIdStore
 package blockstore

--- a/v2/errors.go
+++ b/v2/errors.go
@@ -1,0 +1,18 @@
+package car
+
+import (
+	"fmt"
+)
+
+var _ (error) = (*ErrCidTooLarge)(nil)
+
+// ErrCidTooLarge signals that a CID is too large to include in CARv2 index.
+// See: MaxIndexCidSize.
+type ErrCidTooLarge struct {
+	MaxSize     uint64
+	CurrentSize uint64
+}
+
+func (e *ErrCidTooLarge) Error() string {
+	return fmt.Sprintf("cid size is larger than max allowed (%d > %d)", e.CurrentSize, e.MaxSize)
+}

--- a/v2/errors_test.go
+++ b/v2/errors_test.go
@@ -1,0 +1,12 @@
+package car
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewErrCidTooLarge_ErrorContainsSizes(t *testing.T) {
+	subject := &ErrCidTooLarge{MaxSize: 1413, CurrentSize: 1414}
+	require.EqualError(t, subject, "cid size is larger than max allowed (1414 > 1413)")
+}

--- a/v2/index/indexsorted.go
+++ b/v2/index/indexsorted.go
@@ -207,12 +207,6 @@ func (m *multiWidthIndex) Load(items []Record) error {
 			return err
 		}
 
-		// Ignore records with IDENTITY as required by CARv2 spec.
-		// See: https://ipld.io/specs/transport/car/carv2/#index-format
-		if decHash.Code == multihash.IDENTITY {
-			continue
-		}
-
 		digest := decHash.Digest
 		idx, ok := idxs[len(digest)]
 		if !ok {

--- a/v2/index/indexsorted_test.go
+++ b/v2/index/indexsorted_test.go
@@ -4,9 +4,6 @@ import (
 	"encoding/binary"
 	"testing"
 
-	"github.com/ipfs/go-cid"
-	"github.com/multiformats/go-multihash"
-
 	"github.com/ipfs/go-merkledag"
 	"github.com/multiformats/go-multicodec"
 	"github.com/stretchr/testify/require"
@@ -64,43 +61,4 @@ func TestSingleWidthIndex_GetAll(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, 3, foundCount)
-}
-
-func TestIndexSorted_IgnoresIdentityCids(t *testing.T) {
-	data := []byte("🐟 in da 🌊d")
-	// Generate a record with IDENTITY multihash
-	idMh, err := multihash.Sum(data, multihash.IDENTITY, -1)
-	require.NoError(t, err)
-	idRec := Record{
-		Cid:    cid.NewCidV1(cid.Raw, idMh),
-		Offset: 1,
-	}
-	// Generate a record with non-IDENTITY multihash
-	nonIdMh, err := multihash.Sum(data, multihash.SHA2_256, -1)
-	require.NoError(t, err)
-	noIdRec := Record{
-		Cid:    cid.NewCidV1(cid.Raw, nonIdMh),
-		Offset: 2,
-	}
-
-	subject := newSorted()
-	err = subject.Load([]Record{idRec, noIdRec})
-	require.NoError(t, err)
-
-	// Assert record with IDENTITY CID is not present.
-	err = subject.GetAll(idRec.Cid, func(u uint64) bool {
-		require.Fail(t, "no IDENTITY record shoul be found")
-		return false
-	})
-	require.Equal(t, ErrNotFound, err)
-
-	// Assert record with non-IDENTITY CID is indeed present.
-	var found bool
-	err = subject.GetAll(noIdRec.Cid, func(gotOffset uint64) bool {
-		found = true
-		require.Equal(t, noIdRec.Offset, gotOffset)
-		return false
-	})
-	require.NoError(t, err)
-	require.True(t, found)
 }

--- a/v2/index/mhindexsorted.go
+++ b/v2/index/mhindexsorted.go
@@ -17,7 +17,6 @@ var (
 
 type (
 	// MultihashIndexSorted maps multihash code (i.e. hashing algorithm) to multiWidthCodedIndex.
-	// This index ignores any Record with multihash.IDENTITY.
 	MultihashIndexSorted map[uint64]*multiWidthCodedIndex
 	// multiWidthCodedIndex stores multihash code for each multiWidthIndex.
 	multiWidthCodedIndex struct {
@@ -123,10 +122,6 @@ func (m *MultihashIndexSorted) Load(records []Record) error {
 			return err
 		}
 		code := dmh.Code
-		// Ignore IDENTITY multihash in the index.
-		if code == multihash.IDENTITY {
-			continue
-		}
 		recsByCode, ok := byCode[code]
 		if !ok {
 			recsByCode = make([]Record, 0)

--- a/v2/index/mhindexsorted_test.go
+++ b/v2/index/mhindexsorted_test.go
@@ -20,31 +20,6 @@ func TestMutilhashSortedIndex_Codec(t *testing.T) {
 	require.Equal(t, multicodec.CarMultihashIndexSorted, subject.Codec())
 }
 
-func TestMultiWidthCodedIndex_LoadDoesNotLoadIdentityMultihash(t *testing.T) {
-	rng := rand.New(rand.NewSource(1413))
-	identityRecords := generateIndexRecords(t, multihash.IDENTITY, rng)
-	nonIdentityRecords := generateIndexRecords(t, multihash.SHA2_256, rng)
-	records := append(identityRecords, nonIdentityRecords...)
-
-	subject, err := index.New(multicodec.CarMultihashIndexSorted)
-	require.NoError(t, err)
-	err = subject.Load(records)
-	require.NoError(t, err)
-
-	// Assert index does not contain any records with IDENTITY multihash code.
-	for _, r := range identityRecords {
-		wantCid := r.Cid
-		err = subject.GetAll(wantCid, func(o uint64) bool {
-			require.Fail(t, "subject should not contain any records with IDENTITY multihash code")
-			return false
-		})
-		require.Equal(t, index.ErrNotFound, err)
-	}
-
-	// Assert however, index does contain the non IDENTITY records.
-	requireContainsAll(t, subject, nonIdentityRecords)
-}
-
 func TestMultiWidthCodedIndex_MarshalUnmarshal(t *testing.T) {
 	rng := rand.New(rand.NewSource(1413))
 	records := generateIndexRecords(t, multihash.SHA2_256, rng)

--- a/v2/options.go
+++ b/v2/options.go
@@ -2,6 +2,9 @@ package car
 
 import "github.com/multiformats/go-multicodec"
 
+// DefaultMaxIndexCidSize specifies the maximum size in byptes accepted as a section CID by CARv2 index.
+const DefaultMaxIndexCidSize = 2 << 10 // 2 KiB
+
 // Option describes an option which affects behavior when interacting with CAR files.
 type Option func(*Options)
 
@@ -25,6 +28,8 @@ type Options struct {
 	IndexPadding           uint64
 	IndexCodec             multicodec.Code
 	ZeroLengthSectionAsEOF bool
+	MaxIndexCidSize        uint64
+	StoreIdentityCIDs      bool
 
 	BlockstoreAllowDuplicatePuts bool
 	BlockstoreUseWholeCIDs       bool
@@ -41,6 +46,9 @@ func ApplyOptions(opt ...Option) Options {
 	// Set defaults for zero valued fields.
 	if opts.IndexCodec == 0 {
 		opts.IndexCodec = multicodec.CarMultihashIndexSorted
+	}
+	if opts.MaxIndexCidSize == 0 {
+		opts.MaxIndexCidSize = DefaultMaxIndexCidSize
 	}
 	return opts
 }
@@ -73,5 +81,22 @@ func UseIndexPadding(p uint64) Option {
 func UseIndexCodec(c multicodec.Code) Option {
 	return func(o *Options) {
 		o.IndexCodec = c
+	}
+}
+
+// StoreIdentityCIDs sets whether to persist sections that are referenced by
+// CIDs with multihash.IDENTITY digest.
+// This option is disabled by default.
+func StoreIdentityCIDs(b bool) Option {
+	return func(o *Options) {
+		o.StoreIdentityCIDs = b
+	}
+}
+
+// MaxIndexCidSize specifies the maximum allowed size for indexed CIDs in bytes.
+// Indexing a CID with larger than the allowed size results in ErrCidTooLarge error.
+func MaxIndexCidSize(s uint64) Option {
+	return func(o *Options) {
+		o.MaxIndexCidSize = s
 	}
 }

--- a/v2/options_test.go
+++ b/v2/options_test.go
@@ -1,0 +1,41 @@
+package car_test
+
+import (
+	"testing"
+
+	carv2 "github.com/ipld/go-car/v2"
+	"github.com/ipld/go-car/v2/blockstore"
+	"github.com/multiformats/go-multicodec"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyOptions_SetsExpectedDefaults(t *testing.T) {
+	require.Equal(t, carv2.Options{
+		IndexCodec:      multicodec.CarMultihashIndexSorted,
+		MaxIndexCidSize: carv2.DefaultMaxIndexCidSize,
+	}, carv2.ApplyOptions())
+}
+
+func TestApplyOptions_AppliesOptions(t *testing.T) {
+	require.Equal(t,
+		carv2.Options{
+			DataPadding:                  123,
+			IndexPadding:                 456,
+			IndexCodec:                   multicodec.CarIndexSorted,
+			ZeroLengthSectionAsEOF:       true,
+			MaxIndexCidSize:              789,
+			StoreIdentityCIDs:            true,
+			BlockstoreAllowDuplicatePuts: true,
+			BlockstoreUseWholeCIDs:       true,
+		},
+		carv2.ApplyOptions(
+			carv2.UseDataPadding(123),
+			carv2.UseIndexPadding(456),
+			carv2.UseIndexCodec(multicodec.CarIndexSorted),
+			carv2.ZeroLengthSectionAsEOF(true),
+			carv2.MaxIndexCidSize(789),
+			carv2.StoreIdentityCIDs(true),
+			blockstore.AllowDuplicatePuts(true),
+			blockstore.UseWholeCIDs(true),
+		))
+}


### PR DESCRIPTION
Implement two additional options that allow a CARv2 file to 1) include
IDENTNTIY CIDs, and 2) specify a maximum allowed CID length with default
of 2KiB as a sufficiently large default.

Configure ReadWrite blockstore to persist given blocks with IDENTITY
CIDs.

Introduce a new Characteristics filed that signalls whether an index in
a CAR file contains a full catalog of CIDs for backward compatibility
purposes. Note, this is a new addition and will need to be added to the
spec in a separate PR.

Relates to #215