### PR TITLE
Expose selector traversal options for SelectiveCar

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ipfs/go-ipld-format v0.2.0
 	github.com/ipfs/go-merkledag v0.3.2
 	github.com/ipld/go-codec-dagpb v1.2.0
-	github.com/ipld/go-ipld-prime v0.9.0
+	github.com/ipld/go-ipld-prime v0.12.3-0.20210929125341-05d5528bd84e
 	github.com/multiformats/go-multihash v0.0.15
 	github.com/stretchr/testify v1.7.0
 )

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ipfs/go-ipld-format v0.2.0
 	github.com/ipfs/go-merkledag v0.3.2
 	github.com/ipld/go-codec-dagpb v1.2.0
-	github.com/ipld/go-ipld-prime v0.12.3-0.20210929125341-05d5528bd84e
+	github.com/ipld/go-ipld-prime v0.12.3-0.20210930132912-0b3aef3ca569
 	github.com/multiformats/go-multihash v0.0.15
 	github.com/stretchr/testify v1.7.0
 )

--- a/go.sum
+++ b/go.sum
@@ -116,10 +116,9 @@ github.com/ipfs/go-verifcid v0.0.1 h1:m2HI7zIuR5TFyQ1b79Da5N9dnnCP1vcu2QqawmWlK2
 github.com/ipfs/go-verifcid v0.0.1/go.mod h1:5Hrva5KBeIog4A+UpqlaIU+DEstipcJYQQZc0g37pY0=
 github.com/ipld/go-codec-dagpb v1.2.0 h1:2umV7ud8HBMkRuJgd8gXw95cLhwmcYrihS3cQEy9zpI=
 github.com/ipld/go-codec-dagpb v1.2.0/go.mod h1:6nBN7X7h8EOsEejZGqC7tej5drsdBAXbMHyBT+Fne5s=
-github.com/ipld/go-ipld-prime v0.9.0 h1:N2OjJMb+fhyFPwPnVvJcWU/NsumP8etal+d2v3G4eww=
 github.com/ipld/go-ipld-prime v0.9.0/go.mod h1:KvBLMr4PX1gWptgkzRjVZCrLmSGcZCb/jioOQwCqZN8=
-github.com/ipld/go-ipld-prime v0.12.3-0.20210929125341-05d5528bd84e h1:HPLQ9V/OFHKjfbFio8vQV+EW7lpQPj+iPl93VcwSTYM=
-github.com/ipld/go-ipld-prime v0.12.3-0.20210929125341-05d5528bd84e/go.mod h1:PaeLYq8k6dJLmDUSLrzkEpoGV4PEfe/1OtFN/eALOc8=
+github.com/ipld/go-ipld-prime v0.12.3-0.20210930132912-0b3aef3ca569 h1:UDHkozLpTefhQzyu/2BWVRvsFHjhzvL387KsfFqE1vc=
+github.com/ipld/go-ipld-prime v0.12.3-0.20210930132912-0b3aef3ca569/go.mod h1:PaeLYq8k6dJLmDUSLrzkEpoGV4PEfe/1OtFN/eALOc8=
 github.com/jackpal/gateway v1.0.5 h1:qzXWUJfuMdlLMtt0a3Dgt+xkWQiA5itDEITVJtuSwMc=
 github.com/jackpal/gateway v1.0.5/go.mod h1:lTpwd4ACLXmpyiCTRtfiNyVnUmqT9RivzCDQetPfnjA=
 github.com/jackpal/go-nat-pmp v1.0.1 h1:i0LektDkO1QlrTm/cSuP+PyBCDnYvjPLGl4LdWEMiaA=
@@ -239,6 +238,7 @@ github.com/multiformats/go-multiaddr-net v0.0.1/go.mod h1:nw6HSxNmCIQH27XPGBuX+d
 github.com/multiformats/go-multibase v0.0.1/go.mod h1:bja2MqRZ3ggyXtZSEDKpl0uO/gviWFaSteVbWT51qgs=
 github.com/multiformats/go-multibase v0.0.3 h1:l/B6bJDQjvQ5G52jw4QGSYeOTZoAwIO77RblWplfIqk=
 github.com/multiformats/go-multibase v0.0.3/go.mod h1:5+1R4eQrT3PkYZ24C3W2Ue2tPwIdYQD509ZjSb5y9Oc=
+github.com/multiformats/go-multicodec v0.3.0 h1:tstDwfIjiHbnIjeM5Lp+pMrSeN+LCMsEwOrkPmWm03A=
 github.com/multiformats/go-multicodec v0.3.0/go.mod h1:qGGaQmioCDh+TeFOnxrbU0DaIPw8yFgAZgFG0V7p1qQ=
 github.com/multiformats/go-multihash v0.0.1/go.mod h1:w/5tugSrLEbWqlcgJabL3oHFKTwfvkofsjW2Qa1ct4U=
 github.com/multiformats/go-multihash v0.0.5/go.mod h1:lt/HCbqlQwlPBz7lv0sQCdtfcMtlJvakRUn/0Ual8po=
@@ -282,6 +282,7 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
+github.com/warpfork/go-testmark v0.3.0 h1:Q81c4u7hT+BR5kNfNQhEF0VT2pmL7+Kk0wD+ORYl7iA=
 github.com/warpfork/go-testmark v0.3.0/go.mod h1:jhEf8FVxd+F17juRubpmut64NEG6I2rgkUhlcqqXwE0=
 github.com/warpfork/go-wish v0.0.0-20180510122957-5ad1f5abf436/go.mod h1:x6AKhvSSexNrVSrViXSHUEbICjmGXhtgABaHIySUSGw=
 github.com/warpfork/go-wish v0.0.0-20200122115046-b9ea61034e4a h1:G++j5e0OC488te356JvdhaM8YS6nMsjLAYF7JxCv07w=

--- a/go.sum
+++ b/go.sum
@@ -118,6 +118,8 @@ github.com/ipld/go-codec-dagpb v1.2.0 h1:2umV7ud8HBMkRuJgd8gXw95cLhwmcYrihS3cQEy
 github.com/ipld/go-codec-dagpb v1.2.0/go.mod h1:6nBN7X7h8EOsEejZGqC7tej5drsdBAXbMHyBT+Fne5s=
 github.com/ipld/go-ipld-prime v0.9.0 h1:N2OjJMb+fhyFPwPnVvJcWU/NsumP8etal+d2v3G4eww=
 github.com/ipld/go-ipld-prime v0.9.0/go.mod h1:KvBLMr4PX1gWptgkzRjVZCrLmSGcZCb/jioOQwCqZN8=
+github.com/ipld/go-ipld-prime v0.12.3-0.20210929125341-05d5528bd84e h1:HPLQ9V/OFHKjfbFio8vQV+EW7lpQPj+iPl93VcwSTYM=
+github.com/ipld/go-ipld-prime v0.12.3-0.20210929125341-05d5528bd84e/go.mod h1:PaeLYq8k6dJLmDUSLrzkEpoGV4PEfe/1OtFN/eALOc8=
 github.com/jackpal/gateway v1.0.5 h1:qzXWUJfuMdlLMtt0a3Dgt+xkWQiA5itDEITVJtuSwMc=
 github.com/jackpal/gateway v1.0.5/go.mod h1:lTpwd4ACLXmpyiCTRtfiNyVnUmqT9RivzCDQetPfnjA=
 github.com/jackpal/go-nat-pmp v1.0.1 h1:i0LektDkO1QlrTm/cSuP+PyBCDnYvjPLGl4LdWEMiaA=
@@ -237,6 +239,7 @@ github.com/multiformats/go-multiaddr-net v0.0.1/go.mod h1:nw6HSxNmCIQH27XPGBuX+d
 github.com/multiformats/go-multibase v0.0.1/go.mod h1:bja2MqRZ3ggyXtZSEDKpl0uO/gviWFaSteVbWT51qgs=
 github.com/multiformats/go-multibase v0.0.3 h1:l/B6bJDQjvQ5G52jw4QGSYeOTZoAwIO77RblWplfIqk=
 github.com/multiformats/go-multibase v0.0.3/go.mod h1:5+1R4eQrT3PkYZ24C3W2Ue2tPwIdYQD509ZjSb5y9Oc=
+github.com/multiformats/go-multicodec v0.3.0/go.mod h1:qGGaQmioCDh+TeFOnxrbU0DaIPw8yFgAZgFG0V7p1qQ=
 github.com/multiformats/go-multihash v0.0.1/go.mod h1:w/5tugSrLEbWqlcgJabL3oHFKTwfvkofsjW2Qa1ct4U=
 github.com/multiformats/go-multihash v0.0.5/go.mod h1:lt/HCbqlQwlPBz7lv0sQCdtfcMtlJvakRUn/0Ual8po=
 github.com/multiformats/go-multihash v0.0.10/go.mod h1:YSLudS+Pi8NHE7o6tb3D8vrpKa63epEDmG8nTduyAew=
@@ -279,6 +282,7 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
+github.com/warpfork/go-testmark v0.3.0/go.mod h1:jhEf8FVxd+F17juRubpmut64NEG6I2rgkUhlcqqXwE0=
 github.com/warpfork/go-wish v0.0.0-20180510122957-5ad1f5abf436/go.mod h1:x6AKhvSSexNrVSrViXSHUEbICjmGXhtgABaHIySUSGw=
 github.com/warpfork/go-wish v0.0.0-20200122115046-b9ea61034e4a h1:G++j5e0OC488te356JvdhaM8YS6nMsjLAYF7JxCv07w=
 github.com/warpfork/go-wish v0.0.0-20200122115046-b9ea61034e4a/go.mod h1:x6AKhvSSexNrVSrViXSHUEbICjmGXhtgABaHIySUSGw=

--- a/options.go
+++ b/options.go
@@ -2,7 +2,7 @@ package car
 
 import "math"
 
-// Options holds the configured options after applying a number of
+// options holds the configured options after applying a number of
 // Option funcs.
 type options struct {
 	TraverseLinksOnlyOnce bool
@@ -38,7 +38,7 @@ func MaxTraversalLinks(MaxTraversalLinks uint64) Option {
 	}
 }
 
-// ApplyOptions applies given opts and returns the resulting Options.
+// applyOptions applies given opts and returns the resulting options.
 func applyOptions(opt ...Option) options {
 	opts := options{
 		TraverseLinksOnlyOnce: false,         // default: recurse until exhausted

--- a/options.go
+++ b/options.go
@@ -1,0 +1,56 @@
+package car
+
+import "math"
+
+// Options holds the configured options after applying a number of
+// Option funcs.
+//
+// This type should not be used directly by end users; it's only exposed as a
+// side effect of Option.
+type Options struct {
+	TraverseLinksOnlyOnce bool
+	MaxTraversalLinks     uint64
+}
+
+// Option describes an option which affects behavior when
+// interacting with the  interface.
+type Option func(*Options)
+
+// TraverseLinksOnlyOnce prevents the traversal engine from repeatedly visiting
+// the same links more than once.
+//
+// This can be an efficient strategy for an exhaustive selector where it's known
+// that repeat visits won't impact the completeness of execution. However it
+// should be used with caution with most other selectors as repeat visits of
+// links for different reasons during selector execution can be valid and
+// necessary to perform full traversal.
+func TraverseLinksOnlyOnce() Option {
+	return func(sco *Options) {
+		sco.TraverseLinksOnlyOnce = true
+	}
+}
+
+// MaxTraversalLinks changes the allowed number of links a selector traversal
+// can execute before failing.
+//
+// Note that setting this option may cause an error to be returned from selector
+// execution when building a SelectiveCar.
+func MaxTraversalLinks(MaxTraversalLinks uint64) Option {
+	return func(sco *Options) {
+		sco.MaxTraversalLinks = MaxTraversalLinks
+	}
+}
+
+// ApplyOptions applies given opts and returns the resulting Options.
+// This function should not be used directly by end users; it's only exposed as a
+// side effect of Option.
+func ApplyOptions(opt ...Option) Options {
+	opts := Options{
+		TraverseLinksOnlyOnce: false,         // default: recurse until exhausted
+		MaxTraversalLinks:     math.MaxInt64, // default: traverse all
+	}
+	for _, o := range opt {
+		o(&opts)
+	}
+	return opts
+}

--- a/options.go
+++ b/options.go
@@ -4,17 +4,14 @@ import "math"
 
 // Options holds the configured options after applying a number of
 // Option funcs.
-//
-// This type should not be used directly by end users; it's only exposed as a
-// side effect of Option.
-type Options struct {
+type options struct {
 	TraverseLinksOnlyOnce bool
 	MaxTraversalLinks     uint64
 }
 
 // Option describes an option which affects behavior when
 // interacting with the  interface.
-type Option func(*Options)
+type Option func(*options)
 
 // TraverseLinksOnlyOnce prevents the traversal engine from repeatedly visiting
 // the same links more than once.
@@ -25,7 +22,7 @@ type Option func(*Options)
 // links for different reasons during selector execution can be valid and
 // necessary to perform full traversal.
 func TraverseLinksOnlyOnce() Option {
-	return func(sco *Options) {
+	return func(sco *options) {
 		sco.TraverseLinksOnlyOnce = true
 	}
 }
@@ -36,16 +33,14 @@ func TraverseLinksOnlyOnce() Option {
 // Note that setting this option may cause an error to be returned from selector
 // execution when building a SelectiveCar.
 func MaxTraversalLinks(MaxTraversalLinks uint64) Option {
-	return func(sco *Options) {
+	return func(sco *options) {
 		sco.MaxTraversalLinks = MaxTraversalLinks
 	}
 }
 
 // ApplyOptions applies given opts and returns the resulting Options.
-// This function should not be used directly by end users; it's only exposed as a
-// side effect of Option.
-func ApplyOptions(opt ...Option) Options {
-	opts := Options{
+func applyOptions(opt ...Option) options {
+	opts := options{
 		TraverseLinksOnlyOnce: false,         // default: recurse until exhausted
 		MaxTraversalLinks:     math.MaxInt64, // default: traverse all
 	}

--- a/options_test.go
+++ b/options_test.go
@@ -1,28 +1,27 @@
-package car_test
+package car
 
 import (
 	"math"
 	"testing"
 
-	car "github.com/ipld/go-car"
 	"github.com/stretchr/testify/require"
 )
 
 func TestApplyOptions_SetsExpectedDefaults(t *testing.T) {
-	require.Equal(t, car.Options{
+	require.Equal(t, options{
 		MaxTraversalLinks:     math.MaxInt64,
 		TraverseLinksOnlyOnce: false,
-	}, car.ApplyOptions())
+	}, applyOptions())
 }
 
 func TestApplyOptions_AppliesOptions(t *testing.T) {
 	require.Equal(t,
-		car.Options{
+		options{
 			MaxTraversalLinks:     123,
 			TraverseLinksOnlyOnce: true,
 		},
-		car.ApplyOptions(
-			car.MaxTraversalLinks(123),
-			car.TraverseLinksOnlyOnce(),
+		applyOptions(
+			MaxTraversalLinks(123),
+			TraverseLinksOnlyOnce(),
 		))
 }

--- a/options_test.go
+++ b/options_test.go
@@ -1,0 +1,28 @@
+package car_test
+
+import (
+	"math"
+	"testing"
+
+	car "github.com/ipld/go-car"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyOptions_SetsExpectedDefaults(t *testing.T) {
+	require.Equal(t, car.Options{
+		MaxTraversalLinks:     math.MaxInt64,
+		TraverseLinksOnlyOnce: false,
+	}, car.ApplyOptions())
+}
+
+func TestApplyOptions_AppliesOptions(t *testing.T) {
+	require.Equal(t,
+		car.Options{
+			MaxTraversalLinks:     123,
+			TraverseLinksOnlyOnce: true,
+		},
+		car.ApplyOptions(
+			car.MaxTraversalLinks(123),
+			car.TraverseLinksOnlyOnce(),
+		))
+}

--- a/selectivecar.go
+++ b/selectivecar.go
@@ -276,7 +276,7 @@ func (sct *selectiveCarTraverser) traverseBlocks() error {
 		if sct.sc.opts.maxTraversalLinks < math.MaxInt64 {
 			prog.Budget = &traversal.Budget{
 				NodeBudget: math.MaxInt64,
-				LinkBudget: sct.sc.opts.maxTraversalLinks,
+				LinkBudget: int64(sct.sc.opts.maxTraversalLinks),
 			}
 		}
 		err = prog.WalkAdv(nd, parsed, func(traversal.Progress, ipld.Node, traversal.VisitReason) error { return nil })
@@ -293,7 +293,7 @@ func (sct *selectiveCarTraverser) traverseBlocks() error {
 // This type should not be used directly by end users; it's only exposed as a
 // side effect of SelectiveCarOption.
 type selectiveCarOptions struct {
-	maxTraversalLinks int64
+	maxTraversalLinks uint64
 }
 
 // SelectiveCarOption describes an option which affects behavior when
@@ -304,7 +304,7 @@ type SelectiveCarOption func(*selectiveCarOptions)
 // can execute before failing
 func MaxTraversalLinks(maxTraversalLinks uint64) SelectiveCarOption {
 	return func(sco *selectiveCarOptions) {
-		sco.maxTraversalLinks = int64(maxTraversalLinks)
+		sco.maxTraversalLinks = maxTraversalLinks
 	}
 }
 

--- a/selectivecar.go
+++ b/selectivecar.go
@@ -41,7 +41,7 @@ type SelectiveCar struct {
 	ctx   context.Context
 	dags  []Dag
 	store ReadStore
-	opts  Options
+	opts  options
 }
 
 // OnCarHeaderFunc is called during traversal when the header is created
@@ -68,7 +68,7 @@ func NewSelectiveCar(ctx context.Context, store ReadStore, dags []Dag, opts ...O
 		ctx:   ctx,
 		store: store,
 		dags:  dags,
-		opts:  ApplyOptions(opts...),
+		opts:  applyOptions(opts...),
 	}
 }
 

--- a/selectivecar.go
+++ b/selectivecar.go
@@ -271,6 +271,7 @@ func (sct *selectiveCarTraverser) traverseBlocks() error {
 				Ctx:                            sct.sc.ctx,
 				LinkSystem:                     sct.lsys,
 				LinkTargetNodePrototypeChooser: nsc,
+				LinkVisitOnlyOnce:              sct.sc.opts.TraverseLinksOnlyOnce,
 			},
 		}
 		if sct.sc.opts.MaxTraversalLinks < math.MaxInt64 {

--- a/selectivecar_test.go
+++ b/selectivecar_test.go
@@ -1,0 +1,227 @@
+package car_test
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	blocks "github.com/ipfs/go-block-format"
+	cid "github.com/ipfs/go-cid"
+	format "github.com/ipfs/go-ipld-format"
+	"github.com/ipfs/go-merkledag"
+	dstest "github.com/ipfs/go-merkledag/test"
+	car "github.com/ipld/go-car"
+	basicnode "github.com/ipld/go-ipld-prime/node/basic"
+	"github.com/ipld/go-ipld-prime/traversal/selector"
+	"github.com/ipld/go-ipld-prime/traversal/selector/builder"
+	selectorparse "github.com/ipld/go-ipld-prime/traversal/selector/parse"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRoundtripSelective(t *testing.T) {
+	sourceBserv := dstest.Bserv()
+	sourceBs := sourceBserv.Blockstore()
+	dserv := merkledag.NewDAGService(sourceBserv)
+	a := merkledag.NewRawNode([]byte("aaaa"))
+	b := merkledag.NewRawNode([]byte("bbbb"))
+	c := merkledag.NewRawNode([]byte("cccc"))
+
+	nd1 := &merkledag.ProtoNode{}
+	nd1.AddNodeLink("cat", a)
+
+	nd2 := &merkledag.ProtoNode{}
+	nd2.AddNodeLink("first", nd1)
+	nd2.AddNodeLink("dog", b)
+	nd2.AddNodeLink("repeat", nd1)
+
+	nd3 := &merkledag.ProtoNode{}
+	nd3.AddNodeLink("second", nd2)
+	nd3.AddNodeLink("bear", c)
+
+	assertAddNodes(t, dserv, a, b, c, nd1, nd2, nd3)
+
+	ssb := builder.NewSelectorSpecBuilder(basicnode.Prototype.Any)
+
+	// the graph assembled above looks as follows, in order:
+	// nd3 -> [c, nd2 -> [nd1 -> a, b, nd1 -> a]]
+	// this selector starts at n3, and traverses a link at index 1 (nd2, the second link, zero indexed)
+	// it then recursively traverses all of its children
+	// the only node skipped is 'c' -- link at index 0 immediately below nd3
+	// the purpose is simply to show we are not writing the entire merkledag underneath
+	// nd3
+	selector := ssb.ExploreFields(func(efsb builder.ExploreFieldsSpecBuilder) {
+		efsb.Insert("Links",
+			ssb.ExploreIndex(1, ssb.ExploreRecursive(selector.RecursionLimitNone(), ssb.ExploreAll(ssb.ExploreRecursiveEdge()))))
+	}).Node()
+
+	sc := car.NewSelectiveCar(context.Background(), sourceBs, []car.Dag{{Root: nd3.Cid(), Selector: selector}})
+
+	// write car in one step
+	buf := new(bytes.Buffer)
+	blockCount := 0
+	var oneStepBlocks []car.Block
+	err := sc.Write(buf, func(block car.Block) error {
+		oneStepBlocks = append(oneStepBlocks, block)
+		blockCount++
+		return nil
+	})
+	require.Equal(t, blockCount, 5)
+	require.NoError(t, err)
+
+	// create a new builder for two-step write
+	sc2 := car.NewSelectiveCar(context.Background(), sourceBs, []car.Dag{{Root: nd3.Cid(), Selector: selector}})
+
+	// write car in two steps
+	var twoStepBlocks []car.Block
+	scp, err := sc2.Prepare(func(block car.Block) error {
+		twoStepBlocks = append(twoStepBlocks, block)
+		return nil
+	})
+	require.NoError(t, err)
+	buf2 := new(bytes.Buffer)
+	err = scp.Dump(buf2)
+	require.NoError(t, err)
+
+	// verify preparation step correctly assesed length and blocks
+	require.Equal(t, scp.Size(), uint64(buf.Len()))
+	require.Equal(t, len(scp.Cids()), blockCount)
+
+	// verify equal data written by both methods
+	require.Equal(t, buf.Bytes(), buf2.Bytes())
+
+	// verify equal blocks were passed to user block hook funcs
+	require.Equal(t, oneStepBlocks, twoStepBlocks)
+
+	// readout car and verify contents
+	bserv := dstest.Bserv()
+	ch, err := car.LoadCar(bserv.Blockstore(), buf)
+	require.NoError(t, err)
+	require.Equal(t, len(ch.Roots), 1)
+
+	require.True(t, ch.Roots[0].Equals(nd3.Cid()))
+
+	bs := bserv.Blockstore()
+	for _, nd := range []format.Node{a, b, nd1, nd2, nd3} {
+		has, err := bs.Has(nd.Cid())
+		require.NoError(t, err)
+		require.True(t, has)
+	}
+
+	for _, nd := range []format.Node{c} {
+		has, err := bs.Has(nd.Cid())
+		require.NoError(t, err)
+		require.False(t, has)
+	}
+}
+
+func TestNoLinkRepeatSelective(t *testing.T) {
+	sourceBserv := dstest.Bserv()
+	sourceBs := countingReadStore{bs: sourceBserv.Blockstore()}
+	dserv := merkledag.NewDAGService(sourceBserv)
+	a := merkledag.NewRawNode([]byte("aaaa"))
+	b := merkledag.NewRawNode([]byte("bbbb"))
+	c := merkledag.NewRawNode([]byte("cccc"))
+
+	nd1 := &merkledag.ProtoNode{}
+	nd1.AddNodeLink("cat", a)
+
+	nd2 := &merkledag.ProtoNode{}
+	nd2.AddNodeLink("first", nd1)
+	nd2.AddNodeLink("dog", b)
+	nd2.AddNodeLink("repeat", nd1)
+
+	nd3 := &merkledag.ProtoNode{}
+	nd3.AddNodeLink("second", nd2)
+	nd3.AddNodeLink("bear", c)
+	nd3.AddNodeLink("bearagain1", c)
+	nd3.AddNodeLink("bearagain2", c)
+	nd3.AddNodeLink("bearagain3", c)
+
+	assertAddNodes(t, dserv, a, b, c, nd1, nd2, nd3)
+
+	t.Run("TraverseLinksOnlyOnce off", func(t *testing.T) {
+		sourceBs.count = 0
+		sc := car.NewSelectiveCar(context.Background(),
+			&sourceBs,
+			[]car.Dag{{Root: nd3.Cid(), Selector: selectorparse.CommonSelector_ExploreAllRecursively}},
+		)
+
+		buf := new(bytes.Buffer)
+		blockCount := 0
+		err := sc.Write(buf, func(block car.Block) error {
+			blockCount++
+			return nil
+		})
+		require.Equal(t, blockCount, 6)
+		require.Equal(t, sourceBs.count, 11) // with TraverseLinksOnlyOnce off, we expect repeat block visits because our DAG has repeat links
+		require.NoError(t, err)
+	})
+
+	t.Run("TraverseLinksOnlyOnce on", func(t *testing.T) {
+		sourceBs.count = 0
+
+		sc := car.NewSelectiveCar(context.Background(),
+			&sourceBs,
+			[]car.Dag{{Root: nd3.Cid(), Selector: selectorparse.CommonSelector_ExploreAllRecursively}},
+			car.TraverseLinksOnlyOnce(),
+		)
+
+		buf := new(bytes.Buffer)
+		blockCount := 0
+		err := sc.Write(buf, func(block car.Block) error {
+			blockCount++
+			return nil
+		})
+		require.Equal(t, blockCount, 6)
+		require.Equal(t, sourceBs.count, 6) // only 6 blocks to load, no duplicate loading expected
+		require.NoError(t, err)
+	})
+}
+
+func TestLinkLimitSelective(t *testing.T) {
+	sourceBserv := dstest.Bserv()
+	sourceBs := sourceBserv.Blockstore()
+	dserv := merkledag.NewDAGService(sourceBserv)
+	a := merkledag.NewRawNode([]byte("aaaa"))
+	b := merkledag.NewRawNode([]byte("bbbb"))
+	c := merkledag.NewRawNode([]byte("cccc"))
+
+	nd1 := &merkledag.ProtoNode{}
+	nd1.AddNodeLink("cat", a)
+
+	nd2 := &merkledag.ProtoNode{}
+	nd2.AddNodeLink("first", nd1)
+	nd2.AddNodeLink("dog", b)
+	nd2.AddNodeLink("repeat", nd1)
+
+	nd3 := &merkledag.ProtoNode{}
+	nd3.AddNodeLink("second", nd2)
+	nd3.AddNodeLink("bear", c)
+
+	assertAddNodes(t, dserv, a, b, c, nd1, nd2, nd3)
+
+	sc := car.NewSelectiveCar(context.Background(),
+		sourceBs,
+		[]car.Dag{{Root: nd3.Cid(), Selector: selectorparse.CommonSelector_ExploreAllRecursively}},
+		car.MaxTraversalLinks(2))
+
+	buf := new(bytes.Buffer)
+	blockCount := 0
+	err := sc.Write(buf, func(block car.Block) error {
+		blockCount++
+		return nil
+	})
+	require.Equal(t, blockCount, 3) // root + 2
+	require.Error(t, err)
+	require.Regexp(t, "^traversal budget exceeded: budget for links reached zero while on path .*", err)
+}
+
+type countingReadStore struct {
+	bs    car.ReadStore
+	count int
+}
+
+func (rs *countingReadStore) Get(c cid.Cid) (blocks.Block, error) {
+	rs.count++
+	return rs.bs.Get(c)
+}


### PR DESCRIPTION
Expose `Options` for `NewSelectiveCar()` for two new features available in go-ipld-prime:

1. `traversal.LinkVisitOnlyOnce` which I've called `TraverseLinksOnlyOnce` here - defaulting to `false`
2. `traversal.Budget#LinkBudget` which I've called `MaxTraversalLinks` here - defaulting to _disabled_

I've gone with the same `Options` pattern as in v2 and taken @masih's advice here to keep it generic (rather than use `SelectiveCarOptions`) so the same pattern can be used for the non-selective CAR usage functions. We'll just have to be clear about what options apply to what functions I suppose.

I've put `Traverse` in both option names for this reason - to try and make it clear that they are for selector traversal. But, in the future we could retire the merkledag `Walk` use here and replace it with ipld-prime's traversal (but with `LinkVisitOnlyOnce` enabled by default which would make it equivalent in functionality). So both of these options would make sense for that case too. I'm open to critique of the naming if anyone has stronger opinions.

I also extracted `TestRoundtripSelective` to the new `selectivecar_test.go`, but the other two top-level tests in there are new.