### PR TITLE
feat: fix get-dag and add version=1 option

### DIFF
--- a/cmd/car/car.go
+++ b/cmd/car/car.go
@@ -72,6 +72,11 @@ func main1() int {
 						Name:  "strict",
 						Usage: "Fail if the selector finds links to blocks not in the original car",
 					},
+					&cli.IntFlag{
+						Name:  "version",
+						Value: 2,
+						Usage: "Write output as a v1 or v2 format car",
+					},
 				},
 			},
 			{

--- a/cmd/car/car.go
+++ b/cmd/car/car.go
@@ -91,9 +91,10 @@ func main1() int {
 						Usage:   "The type of index to write",
 						Value:   multicodec.CarMultihashIndexSorted.String(),
 					},
-					&cli.BoolFlag{
-						Name:  "v1",
-						Usage: "Write out only the carV1 file. Implies codec of 'none'",
+					&cli.IntFlag{
+						Name:  "version",
+						Value: 2,
+						Usage: "Write output as a v1 or v2 format car",
 					},
 				},
 			},

--- a/cmd/car/index.go
+++ b/cmd/car/index.go
@@ -23,9 +23,9 @@ func IndexCar(c *cli.Context) error {
 	}
 	defer r.Close()
 
-	if c.Bool("v1") {
+	if c.Int("version") == 1 {
 		if c.IsSet("codec") && c.String("codec") != "none" {
-			return fmt.Errorf("only supported codec for a v1 car is 'none'")
+			return fmt.Errorf("'none' is the only supported codec for a v1 car")
 		}
 		outStream := os.Stdout
 		if c.Args().Len() >= 2 {
@@ -38,6 +38,10 @@ func IndexCar(c *cli.Context) error {
 
 		_, err := io.Copy(outStream, r.DataReader())
 		return err
+	}
+
+	if c.Int("version") != 2 {
+		return fmt.Errorf("invalid CAR version %d", c.Int("version"))
 	}
 
 	var idx index.Index


### PR DESCRIPTION
I was just noticing in #246 that `get-dag` doesn't seem quite right so went about trying to address it, then in the process I'm realising that I don't have much use for CARv2 with much of the stuff I'm interested in and not having the option to make v1 CARs is a bit annoying, so I added a `-version` to it as well.

The current form seems to write out every matching _node_ in a selector, not _block_, which will get pretty gnarly with complex blocks and a match-all and likely not what the user wants. This version uses the selector for the walk only (so it can be an explore, not a match) and uses the block loader to indicate what blocks are visited. It's not entirely unreasonable that a user may want to match individual nodes and turn them into blocks, but I think it's very unlikely desired behaviour and they're thinking in terms of whole blocks contained within the DAG described by a selector that will walk that DAG.

This needs tests, the sample v1 and wrapped v2 are kind of funky, with inlines and some weird stuff that I'm not sure how to account for properly in tests so I was thinking about making a simple DAG that can have selectors run over.

I also wanted to get the same thing for `ipfs dag export` which is exclusively CARv1 (atm anyway): https://github.com/ipfs/go-ipfs/pull/8506 - I was making way for selectors in there too but figure that maybe this is the best place to experiment with some of that crazy, including questions of what to do with excessively linked DAGs that make the traversal too onerous.