### PR TITLE
Seek to start before index generation in `ReadOnly` blockstore

### DIFF
--- a/v2/blockstore/readonly.go
+++ b/v2/blockstore/readonly.go
@@ -150,6 +150,10 @@ func generateIndex(at io.ReaderAt, opts ...carv2.Option) (index.Index, error) {
 	switch r := at.(type) {
 	case io.ReadSeeker:
 		rs = r
+		// The version may have been read from the given io.ReaderAt; therefore move back to the begining.
+		if _, err := rs.Seek(0, io.SeekStart); err != nil {
+			return nil, err
+		}
 	default:
 		rs = internalio.NewOffsetReadSeeker(r, 0)
 	}


### PR DESCRIPTION
The blockstore reads the version of the given CAR payload to determine
whether to generate an index for the given payload or not. When the
payload represents a CARv1 and no index is specified, the backing reader
is passed on for index generation. But the version is already read from
the stream. Seek to the beginning of the backing reader before
generating the index so that the index generation mechanism receives the
complete CARv1.

Fixes #265