### PR TITLE
Allow extracton of a raw unixfs file

### DIFF
--- a/cmd/car/extract.go
+++ b/cmd/car/extract.go
@@ -108,7 +108,7 @@ func extractRoot(c *cli.Context, ls *ipld.LinkSystem, root cid.Cid, outputDir st
 				return err
 			}
 			if ufsNode.DataType.Int() == data.Data_File || ufsNode.DataType.Int() == data.Data_Raw {
-				if err := extractFile(c, ls, pbnode, path.Join(outputResolvedDir, "unknown")); err != nil {
+				if err := extractFile(c, ls, pbnode, filepath.Join(outputResolvedDir, "unknown")); err != nil {
 					return err
 				}
 			}

--- a/cmd/car/extract.go
+++ b/cmd/car/extract.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -94,27 +95,27 @@ func extractRoot(c *cli.Context, ls *ipld.LinkSystem, root cid.Cid, outputDir st
 		}
 	}
 	if err := extractDir(c, ls, ufn, outputResolvedDir, "/"); err != nil {
-		if err == ErrNotDir {
-			ufsData, err := pbnode.LookupByString("Data")
-			if err != nil {
-				return err
-			}
-			ufsBytes, err := ufsData.AsBytes()
-			if err != nil {
-				return err
-			}
-			ufsNode, err := data.DecodeUnixFSData(ufsBytes)
-			if err != nil {
-				return err
-			}
-			if ufsNode.DataType.Int() == data.Data_File || ufsNode.DataType.Int() == data.Data_Raw {
-				if err := extractFile(c, ls, pbnode, filepath.Join(outputResolvedDir, "unknown")); err != nil {
-					return err
-				}
-			}
-			return nil
+		if !errors.Is(err, ErrNotDir) {
+			return fmt.Errorf("%s: %w", root, err)
 		}
-		return fmt.Errorf("%s: %w", root, err)
+		ufsData, err := pbnode.LookupByString("Data")
+		if err != nil {
+			return err
+		}
+		ufsBytes, err := ufsData.AsBytes()
+		if err != nil {
+			return err
+		}
+		ufsNode, err := data.DecodeUnixFSData(ufsBytes)
+		if err != nil {
+			return err
+		}
+		if ufsNode.DataType.Int() == data.Data_File || ufsNode.DataType.Int() == data.Data_Raw {
+			if err := extractFile(c, ls, pbnode, filepath.Join(outputResolvedDir, "unknown")); err != nil {
+				return err
+			}
+		}
+		return nil
 	}
 
 	return nil


### PR DESCRIPTION
If the root of a car is a unixfs file, without the containing directory entry, we can still extract it, we just don't have a filename for it.