### PR TITLE
fix(test): rootless fixture should have no roots, not null roots

### DIFF
--- a/v2/testdata/sample-rootless-v42.car
+++ b/v2/testdata/sample-rootless-v42.car
@@ -1,1 +1,1 @@
-¢erootsögversion*
+¡gversion*


### PR DESCRIPTION
I was trying to use this as a fixture and it's causing a bit of a problem. What we want this fixture to test is that the `version` or `42`, so the error is `invalid car version: 42`. But, because it's got a Null `roots` it violates the schema in a novel way. The schemas for CARv1 headers dictate that the `roots` field is strictly necessary, and not `nullable`, but for the CARv2 pragma, we remove it entirely. So this effectively makes the _initial bytes_ schema something like:

```ipldsch
type CarHeader struct {
  version Int
  roots optional [&Any]
}
```

So it serves both the CARv2 pragma, and the CARv1 header proper.

But this fixture would make it:

```ipldsch
type CarHeader struct {
  version Int
  roots nullable optional [&Any]
}
```

Which introduces additional awkwardness.

So I'd like to hand-wave this problem away entirely.

I'll also note here that it's a bit too easy at the moment to write a CARv1 with a Null in this position, `WriteCar()` and friends, and `ReplaceRootsInFile()` in CARv2 just pass the `roots` value on to `cbor.DumpObject()` which doesn't care about these nuances, it'll write a `nil` as a Null. I'm thinking that maybe we should switch from go-ipld-cbor to bindnode and assert a strict schema for the header to make this go away. The alternative is to add a `nullable` to the CARv1 spec (I started a PR to do this but then thought that maybe it'd be better to sweep this fixture under the carpet and defer this problem till later).