### PR TITLE
feat: Has() and Get() will respect StoreIdentityCIDs option

### DIFF
--- a/v2/blockstore/readonly_test.go
+++ b/v2/blockstore/readonly_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ipfs/go-merkledag"
 	carv2 "github.com/ipld/go-car/v2"
 	"github.com/ipld/go-car/v2/internal/carv1"
+	"github.com/multiformats/go-multicodec"
 	"github.com/stretchr/testify/require"
 )
 
@@ -34,31 +35,53 @@ func TestReadOnly(t *testing.T) {
 		name       string
 		v1OrV2path string
 		opts       []carv2.Option
+		noIdCids   bool
 	}{
 		{
 			"OpenedWithCarV1",
 			"../testdata/sample-v1.car",
 			[]carv2.Option{UseWholeCIDs(true), carv2.StoreIdentityCIDs(true)},
+			// index is made, but identity CIDs are included so they'll be found
+			false,
+		},
+		{
+			"OpenedWithCarV1_NoIdentityCID",
+			"../testdata/sample-v1.car",
+			[]carv2.Option{UseWholeCIDs(true)},
+			// index is made, identity CIDs are not included, but we always short-circuit when StoreIdentityCIDs(false)
+			false,
 		},
 		{
 			"OpenedWithCarV2",
 			"../testdata/sample-wrapped-v2.car",
 			[]carv2.Option{UseWholeCIDs(true), carv2.StoreIdentityCIDs(true)},
+			// index already exists, but was made without identity CIDs, but opening with StoreIdentityCIDs(true) means we check the index
+			true,
+		},
+		{
+			"OpenedWithCarV2_NoIdentityCID",
+			"../testdata/sample-wrapped-v2.car",
+			[]carv2.Option{UseWholeCIDs(true)},
+			// index already exists, it was made without identity CIDs, but we always short-circuit when StoreIdentityCIDs(false)
+			false,
 		},
 		{
 			"OpenedWithCarV1ZeroLenSection",
 			"../testdata/sample-v1-with-zero-len-section.car",
 			[]carv2.Option{UseWholeCIDs(true), carv2.ZeroLengthSectionAsEOF(true)},
+			false,
 		},
 		{
 			"OpenedWithAnotherCarV1ZeroLenSection",
 			"../testdata/sample-v1-with-zero-len-section2.car",
 			[]carv2.Option{UseWholeCIDs(true), carv2.ZeroLengthSectionAsEOF(true)},
+			false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.TODO()
+
 			subject, err := OpenReadOnly(tt.v1OrV2path, tt.opts...)
 			require.NoError(t, err)
 			t.Cleanup(func() { require.NoError(t, subject.Close()) })
@@ -90,7 +113,13 @@ func TestReadOnly(t *testing.T) {
 				// Assert blockstore contains key.
 				has, err := subject.Has(ctx, key)
 				require.NoError(t, err)
-				require.True(t, has)
+				if key.Prefix().MhType == uint64(multicodec.Identity) && tt.noIdCids {
+					// fixture wasn't made with StoreIdentityCIDs, but we opened it with StoreIdentityCIDs,
+					// so they aren't there to find
+					require.False(t, has)
+				} else {
+					require.True(t, has)
+				}
 
 				// Assert size matches block raw data length.
 				gotSize, err := subject.GetSize(ctx, key)
@@ -99,9 +128,11 @@ func TestReadOnly(t *testing.T) {
 				require.Equal(t, wantSize, gotSize)
 
 				// Assert block itself matches v1 payload block.
-				gotBlock, err := subject.Get(ctx, key)
-				require.NoError(t, err)
-				require.Equal(t, wantBlock, gotBlock)
+				if has {
+					gotBlock, err := subject.Get(ctx, key)
+					require.NoError(t, err)
+					require.Equal(t, wantBlock, gotBlock)
+				}
 
 				// Assert write operations error
 				require.Error(t, subject.Put(ctx, wantBlock))

--- a/v2/index_gen.go
+++ b/v2/index_gen.go
@@ -34,6 +34,10 @@ func GenerateIndex(v1r io.Reader, opts ...Option) (index.Index, error) {
 // LoadIndex populates idx with index records generated from r.
 // The r may be in CARv1 or CARv2 format.
 //
+// If the StoreIdentityCIDs option is set when calling LoadIndex, identity
+// CIDs will be included in the index. By default this option is off, and
+// identity CIDs will not be included in the index.
+//
 // Note, the index is re-generated every time even if r is in CARv2 format and already has an index.
 // To read existing index when available see ReadOrGenerateIndex.
 func LoadIndex(idx index.Index, r io.Reader, opts ...Option) error {

--- a/v2/options.go
+++ b/v2/options.go
@@ -127,8 +127,15 @@ func WithoutIndex() Option {
 
 // StoreIdentityCIDs sets whether to persist sections that are referenced by
 // CIDs with multihash.IDENTITY digest.
-// When writing CAR files with this option,
-// Characteristics.IsFullyIndexed will be set.
+// When writing CAR files with this option, Characteristics.IsFullyIndexed will
+// be set.
+//
+// By default, the blockstore interface will always return true for Has() called
+// with identity CIDs, but when this option is turned on, it will defer to the
+// index.
+//
+// When creating an index (or loading a CARv1 as a blockstore), when this option
+// is on, identity CIDs will be included in the index.
 //
 // This option is disabled by default.
 func StoreIdentityCIDs(b bool) Option {


### PR DESCRIPTION
When StoreIdentityCIDs is set, it will defer to the index to check whether the
blocks are in the CAR. When the CAR is a v1 and StoreIdentityCIDs is set, the
index will contain the identity CIDs. When it's a v2 with an existing index,
however that index was created will determine whether the identity CIDs are
that are in the CAR are found.

When StoreIdentityCIDs is not set, Has() will always return true and Get() will
always return the block.

---

The background to this is trying to get identity CID retrievals properly working in Lotus _and_ trying to emulate the `car.SelectiveCar` CAR creation when using the RW blockstore to back a Graphsync transfer. Currently, a Lotus client will use `car.SelectiveCar` to make the CAR for the deal to calculate CommP. Then it'll transfer the CAR to the server, but via Graphsync, the server will not include identity CIDs, so the CommP will not match.

The primary purpose of respecting `StoreIdentityCIDs` for the blockstore interface is so that when backing Graphsync, `Has()` will report correctly whether the block has been stored or not, so that `Put()` will properly write the block into the CAR. Note that `Put()` (actually `PutMany()`) will already respect `StoreIdentityCIDs`, so no change needed there; but `Has()` needs to not return `true` for the block to be put in the first place.

There's two alternatives I think worth considering:

1. Introducing a new option here to handle this functionality, something not called "Store". A new name could help align the slight confusion that may arise in the existing-index case.
2. Entirely ditching `car.SelectiveCar` as the primary method of making CARs for online deals in Lotus—unfortunately this method is widespread, and there's even code in the wild that emulates it! (e.g. https://github.com/filecoin-project/lotus/blob/a843c52e38da13da489cbe6b290ea49b2660b3fb/node/impl/client/client.go#L995). My inclination is to say that this ship sailed when Filecoin was launched - online deals require that identity CIDs appear in the CAR on both sides for CommP to match. This just needs to be fixed on the server side since it was broken when the CARv2 blockstore interface was pushed through Lotus, and we should also bake it into the Filecoin spec perhaps.