### PR TITLE
Implement a streaming read only IPLD native storage

### DIFF
--- a/v2/blockstore/readonlystorage.go
+++ b/v2/blockstore/readonlystorage.go
@@ -1,0 +1,161 @@
+package blockstore
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/ipfs/go-cid"
+	blockstore "github.com/ipfs/go-ipfs-blockstore"
+	carv2 "github.com/ipld/go-car/v2"
+	"github.com/ipld/go-car/v2/index"
+	internalio "github.com/ipld/go-car/v2/internal/io"
+	"github.com/ipld/go-ipld-prime/storage"
+	"github.com/multiformats/go-varint"
+)
+
+var _ storage.ReadableStorage = (*ReadOnlyStorage)(nil)
+var _ storage.StreamingReadableStorage = (*ReadOnlyStorage)(nil)
+
+type ReadOnlyStorage struct {
+	ro *ReadOnly
+}
+
+func NewReadOnlyStorage(backing io.ReaderAt, idx index.Index, opts ...carv2.Option) (*ReadOnlyStorage, error) {
+	ro, err := NewReadOnly(backing, idx, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return &ReadOnlyStorage{ro: ro}, nil
+}
+
+// OpenReadOnlyStorage opens a read-only blockstore from a CAR file (either v1 or v2), generating an index if it does not exist.
+// Note, the generated index if the index does not exist is ephemeral and only stored in memory.
+// See car.GenerateIndex and Index.Attach for persisting index onto a CAR file.
+func OpenReadOnlyStorage(path string, opts ...carv2.Option) (*ReadOnlyStorage, error) {
+	ro, err := OpenReadOnly(path, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return &ReadOnlyStorage{ro: ro}, nil
+}
+
+func (ros *ReadOnlyStorage) Has(ctx context.Context, keyStr string) (bool, error) {
+	// Do the inverse of cid.KeyString(),
+	// which is how a valid key for this adapter must've been produced.
+	key, err := cidFromBinString(keyStr)
+	if err != nil {
+		return false, err
+	}
+
+	return ros.ro.Has(ctx, key)
+}
+
+func (ros *ReadOnlyStorage) Get(ctx context.Context, key string) ([]byte, error) {
+	// Do the inverse of cid.KeyString(),
+	// which is how a valid key for this adapter must've been produced.
+	k, err := cidFromBinString(key)
+	if err != nil {
+		return nil, err
+	}
+
+	// Delegate the Get call.
+	block, err := ros.ro.Get(ctx, k)
+	if err != nil {
+		return nil, err
+	}
+
+	// Unwrap the actual raw data for return.
+	// Discard the rest.  (It's a shame there was an alloc for that structure.)
+	return block.RawData(), nil
+}
+
+func (ros *ReadOnlyStorage) GetStream(ctx context.Context, keyStr string) (io.ReadCloser, error) {
+	// Do the inverse of cid.KeyString(),
+	// which is how a valid key for this adapter must've been produced.
+	key, err := cidFromBinString(keyStr)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check if the given CID has multihash.IDENTITY code
+	// Note, we do this without locking, since there is no shared information to lock for in order to perform the check.
+	if digest, ok, err := isIdentity(key); err != nil {
+		return nil, err
+	} else if ok {
+		return io.NopCloser(bytes.NewReader(digest)), nil
+	}
+
+	ros.ro.mu.RLock()
+	defer ros.ro.mu.RUnlock()
+
+	if ros.ro.closed {
+		return nil, errClosed
+	}
+
+	fnSize := -1
+	var fnErr error
+	var foundOffset int64
+	err = ros.ro.idx.GetAll(key, func(offset uint64) bool {
+		rdr := internalio.NewOffsetReadSeeker(ros.ro.backing, int64(offset))
+		sectionLen, err := varint.ReadUvarint(rdr)
+		if err != nil {
+			fnErr = err
+			return false
+		}
+		cidLen, readCid, err := cid.CidFromReader(rdr)
+		if err != nil {
+			fnErr = err
+			return false
+		}
+		if ros.ro.opts.BlockstoreUseWholeCIDs {
+			if readCid.Equals(key) {
+				fnSize = int(sectionLen) - cidLen
+				foundOffset = rdr.Offset()
+				return false
+			} else {
+				return true // continue looking
+			}
+		} else {
+			if bytes.Equal(readCid.Hash(), key.Hash()) {
+				fnSize = int(sectionLen) - cidLen
+				foundOffset = rdr.Offset()
+			}
+			return false
+		}
+	})
+	if errors.Is(err, index.ErrNotFound) {
+		return nil, blockstore.ErrNotFound
+	} else if err != nil {
+		return nil, err
+	} else if fnErr != nil {
+		return nil, fnErr
+	}
+	if fnSize == -1 {
+		return nil, blockstore.ErrNotFound
+	}
+	return io.NopCloser(io.NewSectionReader(ros.ro.backing, foundOffset, int64(fnSize))), nil
+}
+
+func (ros *ReadOnlyStorage) Close() error {
+	return ros.ro.Close()
+}
+
+func (ros *ReadOnlyStorage) Roots() ([]cid.Cid, error) {
+	return ros.ro.Roots()
+}
+
+// Do the inverse of cid.KeyString().
+// (Unclear why go-cid doesn't offer a function for this itself.)
+func cidFromBinString(key string) (cid.Cid, error) {
+	l, k, err := cid.CidFromBytes([]byte(key))
+	if err != nil {
+		return cid.Undef, fmt.Errorf("key was not a cid: %w", err)
+	}
+	if l != len(key) {
+		return cid.Undef, fmt.Errorf("key was not a cid: had %d bytes leftover", len(key)-l)
+	}
+	return k, nil
+}

--- a/v2/blockstore/readonlystorage_test.go
+++ b/v2/blockstore/readonlystorage_test.go
@@ -1,0 +1,116 @@
+package blockstore
+
+import (
+	"context"
+	"io"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/ipfs/go-cid"
+	blockstore "github.com/ipfs/go-ipfs-blockstore"
+	"github.com/ipfs/go-merkledag"
+	carv2 "github.com/ipld/go-car/v2"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadOnlyStorageGetReturnsBlockstoreNotFoundWhenCidDoesNotExist(t *testing.T) {
+	subject, err := OpenReadOnlyStorage("../testdata/sample-v1.car")
+	require.NoError(t, err)
+	nonExistingKey := merkledag.NewRawNode([]byte("lobstermuncher")).Block.Cid()
+
+	// Assert blockstore API returns blockstore.ErrNotFound
+	gotBlock, err := subject.Get(context.TODO(), string(nonExistingKey.Bytes()))
+	require.Equal(t, blockstore.ErrNotFound, err)
+	require.Nil(t, gotBlock)
+}
+
+func TestReadOnlyStorage(t *testing.T) {
+	tests := []struct {
+		name       string
+		v1OrV2path string
+		opts       []carv2.Option
+	}{
+		{
+			"OpenedWithCarV1",
+			"../testdata/sample-v1.car",
+			[]carv2.Option{UseWholeCIDs(true), carv2.StoreIdentityCIDs(true)},
+		},
+		{
+			"OpenedWithCarV2",
+			"../testdata/sample-wrapped-v2.car",
+			[]carv2.Option{UseWholeCIDs(true), carv2.StoreIdentityCIDs(true)},
+		},
+		{
+			"OpenedWithCarV1ZeroLenSection",
+			"../testdata/sample-v1-with-zero-len-section.car",
+			[]carv2.Option{UseWholeCIDs(true), carv2.ZeroLengthSectionAsEOF(true)},
+		},
+		{
+			"OpenedWithAnotherCarV1ZeroLenSection",
+			"../testdata/sample-v1-with-zero-len-section2.car",
+			[]carv2.Option{UseWholeCIDs(true), carv2.ZeroLengthSectionAsEOF(true)},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.TODO()
+			subject, err := OpenReadOnlyStorage(tt.v1OrV2path, tt.opts...)
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, subject.Close()) })
+
+			f, err := os.Open(tt.v1OrV2path)
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, f.Close()) })
+
+			reader, err := carv2.NewBlockReader(f, tt.opts...)
+			require.NoError(t, err)
+
+			// Assert roots match v1 payload.
+			wantRoots := reader.Roots
+			gotRoots, err := subject.Roots()
+			require.NoError(t, err)
+			require.Equal(t, wantRoots, gotRoots)
+
+			var wantCids []cid.Cid
+			for {
+				wantBlock, err := reader.Next()
+				if err == io.EOF {
+					break
+				}
+				require.NoError(t, err)
+
+				key := wantBlock.Cid()
+				wantCids = append(wantCids, key)
+
+				// Assert blockstore contains key.
+				has, err := subject.Has(ctx, key.KeyString())
+				require.NoError(t, err)
+				require.True(t, has)
+
+				// Assert block itself matches v1 payload block.
+				gotBlock, err := subject.Get(ctx, key.KeyString())
+				require.NoError(t, err)
+				require.Equal(t, wantBlock.RawData(), gotBlock)
+
+				reader, err := subject.GetStream(ctx, key.KeyString())
+				require.NoError(t, err)
+				data, err := io.ReadAll(reader)
+				require.NoError(t, err)
+				require.Equal(t, wantBlock.RawData(), data)
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
+			defer cancel()
+		})
+	}
+}
+
+func TestNewReadOnlyStorageFailsOnUnknownVersion(t *testing.T) {
+	f, err := os.Open("../testdata/sample-rootless-v42.car")
+	require.NoError(t, err)
+	t.Cleanup(func() { f.Close() })
+	subject, err := NewReadOnlyStorage(f, nil)
+	require.Errorf(t, err, "unsupported car version: 42")
+	require.Nil(t, subject)
+}


### PR DESCRIPTION
# Goals

Start to implement CARv2 IPLD Storage native interfaces

# Implementation

So this is definitely just an experiment, but I think it revealed some tangled dependencies in go-car/v2 blockstore interfaces.

Essentially, all I wanted to do was implement a go-ipld-prime `ReadableStorage` interface as defined [here](https://github.com/ipld/go-ipld-prime/blob/master/storage/api.go#LL57) but I also wanted support for native read streaming -- https://github.com/ipld/go-ipld-prime/blob/master/storage/api.go#L91 -- cause I think this is an interesting use case.

To implement the streaming `GetStream` I needed lower level access to the car components, but if I implemented in a seperate package it was tough to get all the functionality of the blockstore interfaces.

I think maybe there's common wrapper code to extract? I dunno I didn't want to do a bunch of refactors.

Ultimately, this was for a particular use case I wanted to try -- I'm not convinced it can be easily written outside the go-car/v2 package, but I'm not not convinced it shouldn't be done that way.