### PR TITLE
feat(cmd): add index create subcommand to create an external carv2 index

### DIFF
--- a/cmd/car/car.go
+++ b/cmd/car/car.go
@@ -153,6 +153,11 @@ func main1() int {
 						Usage: "Write output as a v1 or v2 format car",
 					},
 				},
+				Subcommands: []*cli.Command{{
+					Name:   "create",
+					Usage:  "Write out a detached index",
+					Action: CreateIndex,
+				}},
 			},
 			{
 				Name:   "inspect",

--- a/cmd/car/testdata/script/index-create.txt
+++ b/cmd/car/testdata/script/index-create.txt
@@ -1,0 +1,3 @@
+car index create ${INPUTS}/sample-v1.car sample-v1.car.idx
+car detach-index ${INPUTS}/sample-wrapped-v2.car sample-wrapped-v2.car.idx
+cmp sample-v1.car.idx sample-wrapped-v2.car.idx


### PR DESCRIPTION
Ran into a case where I had a large CARv1 and wanted to create an index from it so I could use the two as a CARv2 blockstore (trying to take a 120GB ~69M block CARv1 of Filecoin state and use it as a blockstore for queries). IIUC this separation of the CARv1 from the index is common in Lotus/Boost and is part of why there's already a `detach` command.

First time contributing to this CLI so lmk if there's a better way you had in mind, or a better place to put this command. We may also want an `index attach` command at some point, but that can be a separate PR.

If people are happy with this, I can add a basic test for this as well (once I figure out the syntax of the test framework).