### PR TITLE
Update install instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,15 +30,12 @@ Most users should use v2, especially for new software, since the v2 API transpar
 
 ## Install
 
-To install the latest version of `go-car/v2` module, run:
+To install the latest version of the `car` executable, run:
 ```shell script
-go get github.com/ipld/go-car/v2
+go install github.com/ipld/go-car/cmd/car@latest
 ```
 
-Alternatively, to install the v0 module, run:
-```shell script
-go get github.com/ipld/go-car
-```
+This will install the `car` executable into `$GOPATH/bin/`
 
 ## API Documentation
 


### PR DESCRIPTION
`go get` is no longer supported outside a module. To build and install a command, use 'go install' with a version. For more information, see https://golang.org/doc/go-get-install-deprecation