### PR TITLE
Allow using WalkOption in WriteCar function

### DIFF
--- a/car.go
+++ b/car.go
@@ -40,11 +40,11 @@ type carWriter struct {
 
 type WalkFunc func(format.Node) ([]*format.Link, error)
 
-func WriteCar(ctx context.Context, ds format.NodeGetter, roots []cid.Cid, w io.Writer) error {
-	return WriteCarWithWalker(ctx, ds, roots, w, DefaultWalkFunc)
+func WriteCar(ctx context.Context, ds format.NodeGetter, roots []cid.Cid, w io.Writer, options ...merkledag.WalkOption) error {
+	return WriteCarWithWalker(ctx, ds, roots, w, DefaultWalkFunc, options...)
 }
 
-func WriteCarWithWalker(ctx context.Context, ds format.NodeGetter, roots []cid.Cid, w io.Writer, walk WalkFunc) error {
+func WriteCarWithWalker(ctx context.Context, ds format.NodeGetter, roots []cid.Cid, w io.Writer, walk WalkFunc, options ...merkledag.WalkOption) error {
 
 	h := &CarHeader{
 		Roots:   roots,
@@ -58,7 +58,7 @@ func WriteCarWithWalker(ctx context.Context, ds format.NodeGetter, roots []cid.C
 	cw := &carWriter{ds: ds, w: w, walk: walk}
 	seen := cid.NewSet()
 	for _, r := range roots {
-		if err := merkledag.Walk(ctx, cw.enumGetLinks, r, seen.Visit); err != nil {
+		if err := merkledag.Walk(ctx, cw.enumGetLinks, r, seen.Visit, options...); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Pass through the `merkledag.WalkOption` parameters to the underlying `merkledag.Walk()` function.

This is helpful for a number of use-cases, in particular it allows creating a CAR with missing nodes. E.g., currently it's not possible to create a CAR with raw links pointing to CIDs not present in the local blockstore. After this change, you can use the following:

```golang
car.WriteCar(ctx, dagService, []cid.Cid{root.Cid()}, carFile, merkledag.IgnoreErrors())
```