### PR TITLE
deps(cmd): update go-internal dependency

### DIFF
--- a/cmd/go.mod
+++ b/cmd/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/multiformats/go-multihash v0.2.1
 	github.com/multiformats/go-varint v0.0.6
 	github.com/polydawn/refmt v0.0.0-20201211092308-30ac6d18308e
-	github.com/rogpeppe/go-internal v1.8.1
+	github.com/rogpeppe/go-internal v1.9.0
 	github.com/urfave/cli/v2 v2.10.3
 	golang.org/x/exp v0.0.0-20220916125017-b168a2c6b86b
 )
@@ -70,6 +70,5 @@ require (
 	golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab // indirect
 	golang.org/x/xerrors v0.0.0-20220609144429-65e65417b02f // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
-	gopkg.in/errgo.v2 v2.1.0 // indirect
 	lukechampine.com/blake3 v1.1.7 // indirect
 )

--- a/cmd/go.sum
+++ b/cmd/go.sum
@@ -819,8 +819,8 @@ github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqn
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
-github.com/rogpeppe/go-internal v1.8.1 h1:geMPLpDpQOgVyCg5z5GoRwLHepNdb71NXb67XFkP+Eg=
-github.com/rogpeppe/go-internal v1.8.1/go.mod h1:JeRgkft04UBgHMgCIwADu4Pn6Mtm5d4nPKWu0nJ5d+o=
+github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
+github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
 github.com/rs/zerolog v1.21.0/go.mod h1:ZPhntP/xmq1nnND05hhpAh2QMhSsA4UN3MGZ6O2J3hM=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
@@ -1235,7 +1235,6 @@ gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/cheggaaa/pb.v1 v1.0.25/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
-gopkg.in/errgo.v2 v2.1.0 h1:0vLT13EuvQ0hNvakwLuFZ/jYrLp5F3kcWHXdRggjCE8=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/gcfg.v1 v1.2.3/go.mod h1:yesOnuUOFQAhST5vPY4nbZsb/huCgGGXlipJsBn0b3o=

--- a/v2/storage/doc.go
+++ b/v2/storage/doc.go
@@ -1,4 +1,4 @@
-// package storage provides a CAR abstraction for the
+// Package storage provides a CAR abstraction for the
 // github.com/ipld/go-ipld-prime/storage interfaces in the form of a StorageCar.
 //
 // THIS PACKAGE IS EXPERIMENTAL. Breaking changes may be introduced in


### PR DESCRIPTION
Crossing my fingers and attempting to fix the new flaky macos CI failures for testing the cmd package. I can replicate it locally after enough test re-runs and haven't been able to replicate it with this update, but it's flaky so that doesn't prove anything.

@mvdan are you aware of anything that might be coming out of testscript that's causing flaky CI executions on macos-only? We see them pretty regularly now, e.g.:

* https://github.com/ipld/go-car/actions/runs/4042032455/jobs/6949254029
* https://github.com/ipld/go-car/actions/runs/4042175271/jobs/6949563292
* https://github.com/ipld/go-car/actions/runs/4120011819/jobs/7114311099
* https://github.com/ipld/go-car/actions/runs/4045723899/jobs/6957586152

They all have the pattern:

```
[signal: killed]
          FAIL: testdata/script/root.txt:1: unexpected command failure
```

where the the script varies, i.e. it happens across different scripts, just on macos.