### PR TITLE
blockstore: fast path for AllKeysChan using the index

### DIFF
--- a/v2/internal/store/insertionindex.go
+++ b/v2/internal/store/insertionindex.go
@@ -152,17 +152,23 @@ func (ii *InsertionIndex) Unmarshal(r io.Reader) error {
 }
 
 func (ii *InsertionIndex) ForEach(f func(multihash.Multihash, uint64) error) error {
-	var errr error
+	var err error
 	ii.items.AscendGreaterOrEqual(ii.items.Min(), func(i llrb.Item) bool {
 		r := i.(recordDigest).Record
-		err := f(r.Cid.Hash(), r.Offset)
-		if err != nil {
-			errr = err
-			return false
-		}
-		return true
+		err = f(r.Cid.Hash(), r.Offset)
+		return err == nil
 	})
-	return errr
+	return err
+}
+
+func (ii *InsertionIndex) ForEachCid(f func(cid.Cid, uint64) error) error {
+	var err error
+	ii.items.AscendGreaterOrEqual(ii.items.Min(), func(i llrb.Item) bool {
+		r := i.(recordDigest).Record
+		err = f(r.Cid, r.Offset)
+		return err == nil
+	})
+	return err
 }
 
 func (ii *InsertionIndex) Codec() multicodec.Code {


### PR DESCRIPTION
Note: I'm not entirely sure I didn't break some assumption.

close https://github.com/ipld/go-car/issues/242

Crude benchmark:
```
func BenchmarkAllKeysChan(b *testing.B) {
	path := filepath.Join(b.TempDir(), "bench-large-v2.car")
	generateRandomCarV2File(b, path, 10<<20) // 10 MiB
	defer os.Remove(path)

	bs, err := blockstore.OpenReadWrite(path, nil)
	if err != nil {
		b.Fatal(err)
	}

	b.ReportAllocs()
	b.ResetTimer()

	for i := 0; i < b.N; i++ {
		c, err := bs.AllKeysChan(context.Background())
		if err != nil {
			b.Fatal(err)
		}
		for range c {
		}
	}
}
```

Before:
> BenchmarkAllKeysChan-12    	     772	   2022389 ns/op	   89049 B/op	    1617 allocs/op

After
> BenchmarkAllKeysChan-12    	    8824	    195779 ns/op	   30865 B/op	     642 allocs/op

10.3X faster, allocate 2.5X less memory.