### PR TITLE
ReadWrite: add an alternative FinalizeReadOnly+Close flow

### DIFF
--- a/v2/blockstore/readwrite.go
+++ b/v2/blockstore/readwrite.go
@@ -243,11 +243,10 @@ func (b *ReadWrite) Finalize() error {
 	b.ronly.mu.Lock()
 	defer b.ronly.mu.Unlock()
 
-	if err := b.finalizeReadOnlyWithoutMutex(); err != nil {
-		return err
-	}
-	if err := b.closeWithoutMutex(); err != nil {
-		return err
+	for _, err := range []error{b.finalizeReadOnlyWithoutMutex(), b.closeWithoutMutex()} {
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
The goal being to be able to keep reading blocks and the index after safely finalizing the file on disk. Typically for indexing purpose.

More tests are likely required, but PR for early feedback.

fix #375 