### PR TITLE
Add WithTrustedCar() reader option

### DIFF
--- a/v2/block_reader.go
+++ b/v2/block_reader.go
@@ -134,6 +134,20 @@ func (br *BlockReader) Next() (blocks.Block, error) {
 	return blocks.NewBlockWithCid(data, c)
 }
 
+// NextInsecure works in the same way as Next(), except it does not re-hash
+// every block to verify that the CID corresponds to the block. It should not
+// be used with untrusted or potentially corrupted CAR files. On the plus side, it is much ligher on the CPU.
+func (br *BlockReader) NextInsecure() (blocks.Block, error) {
+	c, data, err := util.ReadNode(br.r, br.opts.ZeroLengthSectionAsEOF, br.opts.MaxAllowedSectionSize)
+	if err != nil {
+		return nil, err
+	}
+
+	ss := uint64(c.ByteLen()) + uint64(len(data))
+	br.offset += uint64(varint.UvarintSize(ss)) + ss
+	return blocks.NewBlockWithCid(data, c)
+}
+
 type BlockMetadata struct {
 	cid.Cid
 	Offset uint64

--- a/v2/block_reader.go
+++ b/v2/block_reader.go
@@ -120,27 +120,15 @@ func (br *BlockReader) Next() (blocks.Block, error) {
 		return nil, err
 	}
 
-	hashed, err := c.Prefix().Sum(data)
-	if err != nil {
-		return nil, err
-	}
+	if !br.opts.TrustedCAR {
+		hashed, err := c.Prefix().Sum(data)
+		if err != nil {
+			return nil, err
+		}
 
-	if !hashed.Equals(c) {
-		return nil, fmt.Errorf("mismatch in content integrity, expected: %s, got: %s", c, hashed)
-	}
-
-	ss := uint64(c.ByteLen()) + uint64(len(data))
-	br.offset += uint64(varint.UvarintSize(ss)) + ss
-	return blocks.NewBlockWithCid(data, c)
-}
-
-// NextInsecure works in the same way as Next(), except it does not re-hash
-// every block to verify that the CID corresponds to the block. It should not
-// be used with untrusted or potentially corrupted CAR files. On the plus side, it is much ligher on the CPU.
-func (br *BlockReader) NextInsecure() (blocks.Block, error) {
-	c, data, err := util.ReadNode(br.r, br.opts.ZeroLengthSectionAsEOF, br.opts.MaxAllowedSectionSize)
-	if err != nil {
-		return nil, err
+		if !hashed.Equals(c) {
+			return nil, fmt.Errorf("mismatch in content integrity, expected: %s, got: %s", c, hashed)
+		}
 	}
 
 	ss := uint64(c.ByteLen()) + uint64(len(data))

--- a/v2/block_reader_test.go
+++ b/v2/block_reader_test.go
@@ -179,6 +179,41 @@ func TestMaxSectionLength(t *testing.T) {
 	require.True(t, bytes.Equal(block, readBlock.RawData()))
 }
 
+func TestTrustedCAR(t *testing.T) {
+	// headerHex is the zero-roots CARv1 header
+	const headerHex = "11a265726f6f7473806776657273696f6e01"
+	headerBytes, _ := hex.DecodeString(headerHex)
+	// block of zeros
+	block := make([]byte, 5)
+	// CID for that block
+	pfx := cid.NewPrefixV1(cid.Raw, mh.SHA2_256)
+	cid, err := pfx.Sum(block)
+	require.NoError(t, err)
+
+	// Modity the block so it won't match CID anymore
+	block[2] = 0xFF
+	// construct CAR
+	var buf bytes.Buffer
+	buf.Write(headerBytes)
+	buf.Write(varint.ToUvarint(uint64(len(cid.Bytes()) + len(block))))
+	buf.Write(cid.Bytes())
+	buf.Write(block)
+
+	// try to read it as trusted
+	car, err := carv2.NewBlockReader(bytes.NewReader(buf.Bytes()), carv2.WithTrustedCAR(true))
+	require.NoError(t, err)
+	// error should occur on first section read
+	_, err = car.Next()
+	require.NoError(t, err)
+
+	// Try to read it as untrusted - should fail
+	car, err = carv2.NewBlockReader(bytes.NewReader(buf.Bytes()), carv2.WithTrustedCAR(false))
+	require.NoError(t, err)
+	// error should occur on first section read
+	_, err = car.Next()
+	require.EqualError(t, err, "mismatch in content integrity, expected: bafkreieikviivlpbn3cxhuq6njef37ikoysaqxa2cs26zxleqxpay2bzuq, got: bafkreidgklrppelx4fxcsna7cxvo3g7ayedfojkqeuus6kz6e4hy7gukmy")
+}
+
 func TestMaxHeaderLength(t *testing.T) {
 	// headerHex is the is a 5 root CARv1 header
 	const headerHex = "de01a265726f6f747385d82a58250001711220785197229dc8bb1152945da58e2348f7e279eeded06cc2ca736d0e879858b501d82a58250001711220785197229dc8bb1152945da58e2348f7e279eeded06cc2ca736d0e879858b501d82a58250001711220785197229dc8bb1152945da58e2348f7e279eeded06cc2ca736d0e879858b501d82a58250001711220785197229dc8bb1152945da58e2348f7e279eeded06cc2ca736d0e879858b501d82a58250001711220785197229dc8bb1152945da58e2348f7e279eeded06cc2ca736d0e879858b5016776657273696f6e01"

--- a/v2/block_reader_test.go
+++ b/v2/block_reader_test.go
@@ -190,7 +190,7 @@ func TestTrustedCAR(t *testing.T) {
 	cid, err := pfx.Sum(block)
 	require.NoError(t, err)
 
-	// Modity the block so it won't match CID anymore
+	// Modify the block so it won't match CID anymore
 	block[2] = 0xFF
 	// construct CAR
 	var buf bytes.Buffer
@@ -202,7 +202,6 @@ func TestTrustedCAR(t *testing.T) {
 	// try to read it as trusted
 	car, err := carv2.NewBlockReader(bytes.NewReader(buf.Bytes()), carv2.WithTrustedCAR(true))
 	require.NoError(t, err)
-	// error should occur on first section read
 	_, err = car.Next()
 	require.NoError(t, err)
 

--- a/v2/options.go
+++ b/v2/options.go
@@ -60,6 +60,7 @@ type Options struct {
 	MaxTraversalLinks            uint64
 	WriteAsCarV1                 bool
 	TraversalPrototypeChooser    traversal.LinkTargetNodePrototypeChooser
+	TrustedCAR                   bool
 
 	MaxAllowedHeaderSize  uint64
 	MaxAllowedSectionSize uint64
@@ -157,6 +158,14 @@ func MaxIndexCidSize(s uint64) Option {
 func WithTraversalPrototypeChooser(t traversal.LinkTargetNodePrototypeChooser) Option {
 	return func(o *Options) {
 		o.TraversalPrototypeChooser = t
+	}
+}
+
+// WithTrustedCAR specifies whether CIDs match the block data as they are read
+// from the CAR files.
+func WithTrustedCAR(t bool) Option {
+	return func(o *Options) {
+		o.TrustedCAR = t
 	}
 }
 


### PR DESCRIPTION
Attempt to make CAR traversal a little bit faster by not forcing users to hash every single block in a CAR.