### PR TITLE
blockstore: give a direct access to the index for read operations

### DIFF
--- a/v2/blockstore/readonly.go
+++ b/v2/blockstore/readonly.go
@@ -179,6 +179,12 @@ func OpenReadOnly(path string, opts ...carv2.Option) (*ReadOnly, error) {
 	return robs, nil
 }
 
+// Index gives direct access to the index.
+// You should never add records on your own there.
+func (b *ReadOnly) Index() index.Index {
+	return b.idx
+}
+
 // DeleteBlock is unsupported and always errors.
 func (b *ReadOnly) DeleteBlock(_ context.Context, _ cid.Cid) error {
 	return errReadOnly

--- a/v2/blockstore/readwrite.go
+++ b/v2/blockstore/readwrite.go
@@ -10,6 +10,7 @@ import (
 	blocks "github.com/ipfs/go-libipfs/blocks"
 
 	carv2 "github.com/ipld/go-car/v2"
+	"github.com/ipld/go-car/v2/index"
 	"github.com/ipld/go-car/v2/internal/carv1"
 	"github.com/ipld/go-car/v2/internal/carv1/util"
 	internalio "github.com/ipld/go-car/v2/internal/io"
@@ -176,6 +177,12 @@ func (b *ReadWrite) initWithRoots(v2 bool, roots []cid.Cid) error {
 		}
 	}
 	return carv1.WriteHeader(&carv1.CarHeader{Roots: roots, Version: 1}, b.dataWriter)
+}
+
+// Index gives direct access to the index.
+// You should never add records on your own there.
+func (b *ReadWrite) Index() index.Index {
+	return b.idx
 }
 
 // Put puts a given block to the underlying datastore

--- a/v2/index/index.go
+++ b/v2/index/index.go
@@ -134,7 +134,7 @@ func WriteTo(idx Index, w io.Writer) (uint64, error) {
 // Returns error if the encoding is not known.
 //
 // Attempting to read index data from untrusted sources is not recommended.
-// Instead the index should be regenerated from the CARv2 data payload.
+// Instead, the index should be regenerated from the CARv2 data payload.
 func ReadFrom(r io.Reader) (Index, error) {
 	codec, err := ReadCodec(r)
 	if err != nil {


### PR DESCRIPTION
This can be useful for advanced read-only operation, like indexing.