### PR TITLE
fix: handle (and test) WholeCID vs not; fast Has() path for storage

### DIFF
--- a/v2/internal/store/indexcheck.go
+++ b/v2/internal/store/indexcheck.go
@@ -55,3 +55,30 @@ func ShouldPut(
 
 	return true, nil
 }
+
+// Has returns true if the block exists in in the store according to the various
+// rules associated with the options. Similar to ShouldPut, but for the simpler
+// Has() case.
+func Has(
+	idx *InsertionIndex,
+	c cid.Cid,
+	maxIndexCidSize uint64,
+	storeIdentityCIDs bool,
+	blockstoreAllowDuplicatePuts bool,
+	blockstoreUseWholeCIDs bool,
+) (bool, error) {
+
+	// If StoreIdentityCIDs option is disabled then treat IDENTITY CIDs like IdStore.
+	if !storeIdentityCIDs {
+		if _, ok, err := IsIdentity(c); err != nil {
+			return false, err
+		} else if ok {
+			return true, nil
+		}
+	}
+
+	if blockstoreUseWholeCIDs {
+		return idx.HasExactCID(c)
+	}
+	return idx.HasMultihash(c.Hash())
+}


### PR DESCRIPTION
I realised too late that #393 didn't have the whole CID vs multihash differentiation in its new Has() that it needs to have. So adding it back in here and giving the same fast-path treatment to the storage API that blockstore has from #393.