### PR TITLE
fix: reading from stdin should broadcast EOF to block loaders

### DIFF
--- a/cmd/car/extract.go
+++ b/cmd/car/extract.go
@@ -215,7 +215,7 @@ func extractDir(c *cli.Context, ls *ipld.LinkSystem, n ipld.Node, outputRoot, ou
 				return 0, err
 			}
 			if c.IsSet("verbose") {
-				fmt.Fprintf(c.App.Writer, "%s\n", nextRes)
+				fmt.Fprintf(c.App.ErrWriter, "%s\n", nextRes)
 			}
 		}
 
@@ -401,6 +401,7 @@ func NewStdinReadStorage(reader io.Reader) (*stdinReadStorage, []cid.Cid, error)
 			if err == io.EOF {
 				srs.lk.Lock()
 				srs.done = true
+				srs.cond.Broadcast()
 				srs.lk.Unlock()
 				return
 			}

--- a/cmd/car/testdata/script/create-extract.txt
+++ b/cmd/car/testdata/script/create-extract.txt
@@ -1,7 +1,7 @@
 car create --file=out.car foo.txt bar.txt
 mkdir out
 car extract -v -f out.car out
-stdout -count=2 'txt$'
+stderr -count=2 'txt$'
 stderr -count=1 '^extracted 2 file\(s\)$'
 car create --file=out2.car out/foo.txt out/bar.txt
 cmp out.car out2.car


### PR DESCRIPTION
otherwise results in a blocking wait when you do an extract-all but there are missing blocks that you're waiting for a "done" signal for.