### PR TITLE
perf: reduce NewCarReader allocations

### DIFF
--- a/car_test.go
+++ b/car_test.go
@@ -227,3 +227,27 @@ func TestBadHeaders(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkNewCarReader_small(b *testing.B) {
+	b.ReportAllocs()
+
+	fixture, err := hex.DecodeString(fixtureStr)
+	if err != nil {
+		b.Fatal(err)
+	}
+	for i := 0; i < b.N; i++ {
+		cr, err := car.NewCarReader(bytes.NewReader(fixture))
+		if err != nil {
+			b.Fatal(err)
+		}
+		for {
+			_, err := cr.Next()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+}


### PR DESCRIPTION
This accounted for almost 10% of the garbage on one of Bluesky's server daemons (go tool pprof --alloc_space), leading to high GC CPU.

benchstat:

                         │   before    │                after                │
                         │   sec/op    │   sec/op     vs base                │
    NewCarReader_small-8   2.005µ ± 1%   1.451µ ± 5%  -27.61% (p=0.000 n=10)

                         │    before    │                after                 │
                         │     B/op     │     B/op      vs base                │
    NewCarReader_small-8   5.268Ki ± 0%   1.135Ki ± 0%  -78.46% (p=0.000 n=10)

                         │   before   │               after               │
                         │ allocs/op  │ allocs/op   vs base               │
    NewCarReader_small-8   29.00 ± 0%   27.00 ± 0%  -6.90% (p=0.000 n=10)