### PR TITLE
feat(cmd/car): add '--no-wrap' option to 'create' command

### DIFF
--- a/cmd/car/car.go
+++ b/cmd/car/car.go
@@ -40,6 +40,10 @@ func main1() int {
 						Usage:     "The car file to write to",
 						TakesFile: true,
 					},
+					&cli.BoolFlag{
+						Name:  "no-wrap",
+						Usage: "Do not wrap the files in a directory",
+					},
 					&cli.IntFlag{
 						Name:  "version",
 						Value: 2,


### PR DESCRIPTION
This was something I found that could be useful when creating CARs. Let me know what you think. I created a negative flag since the default is to wrap, not changing the default.