### PR TITLE
feat: add inverse and version to filter cmd

### DIFF
--- a/cmd/car/car.go
+++ b/cmd/car/car.go
@@ -116,6 +116,16 @@ func main1() int {
 						Name:  "append",
 						Usage: "Append cids to an existing output file",
 					},
+					&cli.BoolFlag{
+						Name:  "inverse",
+						Usage: "Inverse the filter (this will remove cids from the car file)",
+						Value: false,
+					},
+					&cli.IntFlag{
+						Name:  "version",
+						Value: 2,
+						Usage: "Write output as a v1 or v2 format car",
+					},
 				},
 			},
 			{


### PR DESCRIPTION
Adds the options `--version` and `--inverse` to `car filter` so that:

```sh
echo $REMOVED_CID | car filter --version 1 --inverse ./input.car ./output.car
```

Removes the CID and outputs a carv1.

Context:
- `--inverse` is useful to filter out a CID out of a car, related: https://github.com/ipfs/gateway-conformance/issues/75
- `--version` is required to workaround https://github.com/ipfs/kubo/issues/9361