### PR TITLE
v0.6.2 bump

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.6.1"
+  "version": "v0.6.2"
 }


### PR DESCRIPTION
Adds support for a v1 car reader that is okay with an empty `roots` array in the header.