### PR TITLE
Add an `AbsoluteIndexOffsets` option for readonly blockstore

### DIFF
--- a/v2/blockstore/readwrite.go
+++ b/v2/blockstore/readwrite.go
@@ -141,6 +141,7 @@ func OpenReadWriteFile(f *os.File, roots []cid.Cid, opts ...carv2.Option) (*Read
 		return nil, err
 	}
 	rwbs.ronly.backing = v1r
+	rwbs.ronly.indexBacking = v1r
 	rwbs.ronly.idx = rwbs.idx
 
 	if resume {

--- a/v2/options.go
+++ b/v2/options.go
@@ -57,6 +57,7 @@ type Options struct {
 
 	BlockstoreAllowDuplicatePuts bool
 	BlockstoreUseWholeCIDs       bool
+	AbsoluteIndexOffsets         bool
 	MaxTraversalLinks            uint64
 	WriteAsCarV1                 bool
 	TraversalPrototypeChooser    traversal.LinkTargetNodePrototypeChooser
@@ -236,5 +237,14 @@ func WriteAsCarV1(asCarV1 bool) Option {
 func AllowDuplicatePuts(allow bool) Option {
 	return func(o *Options) {
 		o.BlockstoreAllowDuplicatePuts = allow
+	}
+}
+
+// WithAbsoluteIndexOffsets is a read option which interprets index offsets as
+// absolute offsets from the beginning of the CARv2 file, instead of relative
+// offsets from the beginning of the Carv1 header.
+func WithAbsoluteIndexOffsets(absolute bool) Option {
+	return func(o *Options) {
+		o.AbsoluteIndexOffsets = absolute
 	}
 }


### PR DESCRIPTION
Allow opening a blockstore with an index that has offsets from the beginning of the car file, rather than from the beginning of the carv1 contained file.

Absolute indexes of this type are generated by boost. Once the car is stored to a remote location separate from the index, it's unclear if it was a v1 or v2 car. Using an absolute index means individual CIDs can be efficiently fetched without re-parses of the header.
The carv2 blockstore is used over this situation by boost for cases where a blockstore interface is needed. in this case, we would like to be able to support a mode where the reader offset for index reads doesn't offset based on the indicated start of the data section in the carv2 header.