### PR TITLE
fix: BlockMetadata#Offset should be for section, not block data

### DIFF
--- a/v2/block_reader_test.go
+++ b/v2/block_reader_test.go
@@ -245,6 +245,10 @@ func TestBlockReader(t *testing.T) {
 	vb := make([]byte, 2)
 	for i := 0; i < 100; i++ {
 		blk := randBlock(100 + i) // we should cross the varint two-byte boundary in here somewhere
+		blks[i] = struct {
+			block      blocks.Block
+			dataOffset uint64
+		}{block: blk, dataOffset: uint64(v1buf.Len())}
 		vn := varint.PutUvarint(vb, uint64(len(blk.Cid().Bytes())+len(blk.RawData())))
 		n, err := v1buf.Write(vb[:vn])
 		req.NoError(err)
@@ -252,10 +256,6 @@ func TestBlockReader(t *testing.T) {
 		n, err = v1buf.Write(blk.Cid().Bytes())
 		req.NoError(err)
 		req.Equal(len(blk.Cid().Bytes()), n)
-		blks[i] = struct {
-			block      blocks.Block
-			dataOffset uint64
-		}{block: blk, dataOffset: uint64(v1buf.Len())}
 		n, err = v1buf.Write(blk.RawData())
 		req.NoError(err)
 		req.Equal(len(blk.RawData()), n)


### PR DESCRIPTION
@willscott while the CARv2 offsets were completely broken prior to #491 and I made it match for both CARv1 and CARv2; I changed the meaning of "Offset" in the process, making it the data offset, not section offset. Unfortunately because there were no tests or docs in there the intention wasn't clear so I made an assumption. I just discovered this after updating go-car in vanilla Boost and getting the section read errors ("bad cid version").

So this is a bugfix, to change it back to section offset but also make both CARv1 and CARv2 work (+ docs + tests).