### PR TITLE
fix: goreleaser v2 compat, trigger release-binaries with workflow_run

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -2,7 +2,10 @@ name: GoReleaser
 on:
   release:
     types: [ published ]
-
+  workflow_dispatch:
+  workflow_run:
+    workflows: [Releaser]
+    types: [completed]
 jobs:
   bin-releaser:
     name: Release Binaries
@@ -15,12 +18,12 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.19.x"
+          go-version: "1.22.x"
       - name: Release Binaries
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,3 +1,6 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema-pro.json
+
+version: 2
 builds:
   - main: ./car
     dir: cmd
@@ -20,5 +23,4 @@ archives:
 release:
   mode: keep-existing
 changelog:
-  skip: true
-
+  disable: true


### PR DESCRIPTION
Ref: https://github.com/ipld/go-car/issues/536

(a small amount of 🤞 going on here, we'll see, this works for lassie)