### PR TITLE
Revert "ci: uci/update-go (#602)"

### DIFF
--- a/cmd/go.mod
+++ b/cmd/go.mod
@@ -1,6 +1,6 @@
 module github.com/ipld/go-car/cmd
 
-go 1.24
+go 1.23.10
 
 require (
 	github.com/dustin/go-humanize v1.0.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ipld/go-car
 
-go 1.24
+go 1.23.10
 
 require (
 	github.com/ipfs/boxo v0.33.1

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -1,6 +1,6 @@
 module github.com/ipld/go-car/v2
 
-go 1.24
+go 1.23.10
 
 require (
 	github.com/ipfs/go-block-format v0.2.2


### PR DESCRIPTION
This reverts commit 76b9ce47ee9c75907298eab3029c22d05dd824e7.

Putting back 1.23 support while we get #603 in.