### PR TITLE
feat/refac(cmd): Get rid of "--unixfs-blocks", introduce "--cids" and "--sizes"

### DIFF
--- a/cmd/car/car.go
+++ b/cmd/car/car.go
@@ -227,6 +227,13 @@ func main1() int {
 						Usage:       "Include CIDs",
 						DefaultText: "true except for unixfs",
 					},
+					&cli.StringFlag{
+						Name:        "sizes",
+						Aliases:     []string{"s"},
+						Usage:       "Include sizes (specify \"human\" or \"bytes\")",
+						Value:       "",
+						DefaultText: "human for verbose, none otherwise",
+					},
 					&cli.BoolFlag{
 						Name:  "unixfs",
 						Usage: "Show unixfs filesystem (full paths)",

--- a/cmd/car/car.go
+++ b/cmd/car/car.go
@@ -213,21 +213,23 @@ func main1() int {
 			{
 				Name:    "list",
 				Aliases: []string{"l", "ls"},
-				Usage:   "List the CIDs in a car",
+				Usage:   "List the blocks in a car",
 				Action:  ListCar,
 				Flags: []cli.Flag{
 					&cli.BoolFlag{
 						Name:    "verbose",
 						Aliases: []string{"v"},
-						Usage:   "Include verbose information about contained blocks",
+						Usage:   "Show verbose information about contained blocks",
+					},
+					&cli.BoolFlag{
+						Name:        "cids",
+						Value:       true,
+						Usage:       "Include CIDs",
+						DefaultText: "true except for unixfs",
 					},
 					&cli.BoolFlag{
 						Name:  "unixfs",
-						Usage: "List unixfs filesystem from the root of the car",
-					},
-					&cli.BoolFlag{
-						Name:  "unixfs-blocks",
-						Usage: "List blocks of unixfs objects in the car",
+						Usage: "Show unixfs filesystem (full paths)",
 					},
 				},
 			},


### PR DESCRIPTION
Help section with this pull request:

```
NAME:
   car list - List the blocks in a car

USAGE:
   car list [command options]

OPTIONS:
   --verbose, -v            Show verbose information about contained blocks (default: false)
   --cids                   Include CIDs (default: true except for unixfs)
   --sizes value, -s value  Include sizes (specify "human" or "bytes") (default: human for verbose, none otherwise)
   --unixfs                 Show unixfs filesystem (full paths) (default: false)
   --help, -h               show help
```