### PR TITLE
fix: remove broken trailing data check in "inspect --full" for CARv1

### DIFF
--- a/cmd/car/lib/inspect.go
+++ b/cmd/car/lib/inspect.go
@@ -3,7 +3,6 @@ package lib
 import (
 	"bytes"
 	"fmt"
-	"io"
 	"os"
 	"sort"
 	"strings"
@@ -123,15 +122,6 @@ func InspectCar(inStream *os.File, verifyHashes bool) (*Report, error) {
 	stats, err := rd.Inspect(verifyHashes)
 	if err != nil {
 		return nil, err
-	}
-
-	if stats.Version == 1 && verifyHashes { // check that we've read all the data
-		got, err := inStream.Read(make([]byte, 1)) // force EOF
-		if err != nil && err != io.EOF {
-			return nil, err
-		} else if got > 0 {
-			return nil, fmt.Errorf("unexpected data after EOF: %d", got)
-		}
 	}
 
 	rep := Report{

--- a/cmd/car/testdata/script/inspect.txt
+++ b/cmd/car/testdata/script/inspect.txt
@@ -1,7 +1,13 @@
 car inspect ${INPUTS}/sample-v1.car
 cmp stdout v1inspect.txt
 
+car inspect --full ${INPUTS}/sample-v1.car
+cmp stdout v1inspect.txt
+
 car inspect ${INPUTS}/sample-wrapped-v2.car
+cmp stdout v2inspect.txt
+
+car inspect --full ${INPUTS}/sample-wrapped-v2.car
 cmp stdout v2inspect.txt
 
 ! car inspect ${INPUTS}/badheaderlength.car


### PR DESCRIPTION
trailing-data check neither works because of the offsetReadSeeker wapping which means we're re-reading at position 0 anyway, plus malformed trailing bytes should already be caught by section read errors

Fixes: https://github.com/ipld/go-car/issues/652

This is a partial revert of dbd9059 which came in with #384 and I'm really not sure why it was added there, you can't stream to this command AFAIK, maybe I was inspecting some streamed CARs at the time and encountering something related to this.