### PR TITLE
fix: use `%w` when wrapping errors to preserve error chain

### DIFF
--- a/car.go
+++ b/car.go
@@ -53,7 +53,7 @@ func WriteCarWithWalker(ctx context.Context, ds format.NodeGetter, roots []cid.C
 	}
 
 	if err := WriteHeader(h, w); err != nil {
-		return fmt.Errorf("failed to write car header: %s", err)
+		return fmt.Errorf("failed to write car header: %w", err)
 	}
 
 	cw := &carWriter{ds: ds, w: w, walk: walk}

--- a/selectivecar.go
+++ b/selectivecar.go
@@ -102,7 +102,7 @@ func (sc SelectiveCar) Prepare(userOnNewCarBlocks ...OnNewCarBlockFunc) (Selecti
 func (sc SelectiveCar) Write(w io.Writer, userOnNewCarBlocks ...OnNewCarBlockFunc) error {
 	onCarHeader := func(h CarHeader) error {
 		if err := WriteHeader(&h, w); err != nil {
-			return fmt.Errorf("failed to write car header: %s", err)
+			return fmt.Errorf("failed to write car header: %w", err)
 		}
 		return nil
 	}
@@ -143,10 +143,10 @@ func (sc SelectiveCarPrepared) Cids() []cid.Cid {
 func (sc SelectiveCarPrepared) Dump(ctx context.Context, w io.Writer) error {
 	offset, err := HeaderSize(&sc.header)
 	if err != nil {
-		return fmt.Errorf("failed to size car header: %s", err)
+		return fmt.Errorf("failed to size car header: %w", err)
 	}
 	if err := WriteHeader(&sc.header, w); err != nil {
-		return fmt.Errorf("failed to write car header: %s", err)
+		return fmt.Errorf("failed to write car header: %w", err)
 	}
 	for _, c := range sc.cids {
 		blk, err := sc.store.Get(ctx, c)

--- a/v2/selective.go
+++ b/v2/selective.go
@@ -267,7 +267,7 @@ func traverse(ctx context.Context, ls *ipld.LinkSystem, root cid.Cid, s ipld.Nod
 	}
 	rootNode, err := ls.Load(ipld.LinkContext{}, lnk, rp)
 	if err != nil {
-		return fmt.Errorf("root blk load failed: %s", err)
+		return fmt.Errorf("root blk load failed: %w", err)
 	}
 	err = progress.WalkMatching(rootNode, sel, func(_ traversal.Progress, node ipld.Node) error {
 		if lbn, ok := node.(datamodel.LargeBytesNode); ok {
@@ -283,7 +283,7 @@ func traverse(ctx context.Context, ls *ipld.LinkSystem, root cid.Cid, s ipld.Nod
 		return nil
 	})
 	if err != nil {
-		return fmt.Errorf("walk failed: %s", err)
+		return fmt.Errorf("walk failed: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
# Fix: preserve error chain when wrapping with %w

## Summary

Use `%w` instead of `%s` when wrapping errors so that underlying errors remain in the chain. This allows callers (e.g. **IPFS Kubo**) to use `errors.Is(err, ipld.ErrNotFound{})` and to detect boxo’s “block was not found locally” and other sentinel errors.

Ref: IPFS Kubo https://github.com/ipfs/kubo/issues/10826  Kubo and other consumers need to detect `ipld.ErrNotFound` (and related “block not found” errors) through the wrapped error. With `%s`, the chain was broken and `errors.Is` could not see the original error.
