### PR TITLE
chore: remove dependabot groups for updatability

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,6 @@ updates:
       interval: "monthly"
     cooldown:
       default-days: 5
-    groups:
-      shared-dependencies:
-        group-by: "dependency-name"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Ran into this and it's annoying: https://github.com/dependabot/dependabot-core/issues/14780